### PR TITLE
add session-exported message during export

### DIFF
--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -195,6 +195,7 @@ class FileExportManager {
                 return partitionedNetworks.map((partitionedNetwork) => {
                   const partitionedEntity = partitionedNetwork.partitionEntity;
                   if (!finishedSessions.includes(prefix)) {
+                    this.emit('session-exported', session.sessionVariables.sessionId);
                     this.emit('update', ProgressMessages.ExportSession(finishedSessions.length + 1, sessionExportTotal));
                     finishedSessions.push(prefix);
                   }


### PR DESCRIPTION
Emits an additional message during export that is used to mark a session as having been exported.