### PR TITLE
Use commonjs style exports

### DIFF
--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -1,4 +1,4 @@
-const { merge, isEmpty, groupBy, flattenDeep } = require('lodash');
+const { merge, isEmpty, groupBy, flattenDeep, first } = require('lodash');
 const { EventEmitter } = require('eventemitter3');
 const sanitizeFilename = require('sanitize-filename');
 const {
@@ -267,11 +267,15 @@ class FileExportManager {
             }
 
             const dialog = electron.dialog;
+            const browserWindow = first(electron.BrowserWindow.getAllWindows());
 
-            dialog.showSaveDialog({
-              filters: [{ name: 'zip', extensions: ['zip'] }],
-              defaultPath: 'networkCanvasExport.zip',
-            })
+            dialog.showSaveDialog(
+              browserWindow,
+              {
+                filters: [{ name: 'zip', extensions: ['zip'] }],
+                defaultPath: 'networkCanvasExport.zip',
+              },
+            )
               .then(({ canceled, filePath }) => {
                 if (canceled) { resolve(); }
 

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -1,30 +1,30 @@
-import { merge, isEmpty, groupBy, flattenDeep } from 'lodash';
-import { EventEmitter } from 'eventemitter3';
-import sanitizeFilename from 'sanitize-filename';
-import {
+const { merge, isEmpty, groupBy, flattenDeep } = require('lodash');
+const { EventEmitter } = require('eventemitter3');
+const sanitizeFilename = require('sanitize-filename');
+const {
   caseProperty,
   sessionProperty,
   protocolProperty,
-} from './utils/reservedAttributes';
-import {
+} = require('./utils/reservedAttributes');
+const {
   getFileNativePath,
   rename,
   removeDirectory,
   makeTempDir,
-} from './utils/filesystem';
-import exportFile from './exportFile';
-import {
+} = require('./utils/filesystem');
+const exportFile = require('./exportFile');
+const {
   insertEgoIntoSessionNetworks,
   resequenceIds,
   partitionNetworkByType,
   unionOfNetworks,
-} from './formatters/network';
-import { verifySessionVariables } from './utils/general';
-import { isCordova, isElectron } from './utils/Environment';
-import archive from './utils/archive';
-import { ExportError, ErrorMessages } from './errors/ExportError';
-import ProgressMessages from './ProgressMessages';
-import UserCancelledExport from './errors/UserCancelledExport';
+} = require('./formatters/network');
+const { verifySessionVariables } = require('./utils/general');
+const { isCordova, isElectron } = require('./utils/Environment');
+const archive = require('./utils/archive');
+const { ExportError, ErrorMessages } = require('./errors/ExportError');
+const ProgressMessages = require('./ProgressMessages');
+const UserCancelledExport = require('./errors/UserCancelledExport');
 
 /**
  * Interface for all data exports
@@ -324,4 +324,4 @@ class FileExportManager {
   }
 }
 
-export default FileExportManager;
+module.exports = FileExportManager;

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const { merge, isEmpty, groupBy, flattenDeep, first } = require('lodash');
 const { EventEmitter } = require('eventemitter3');
 const sanitizeFilename = require('sanitize-filename');
@@ -23,8 +24,8 @@ const { verifySessionVariables } = require('./utils/general');
 const { isCordova, isElectron } = require('./utils/Environment');
 const archive = require('./utils/archive');
 const { ExportError, ErrorMessages } = require('./errors/ExportError');
-const { ProgressMessages } = require('./ProgressMessages');
-const { UserCancelledExport } = require('./errors/UserCancelledExport');
+const ProgressMessages = require('./ProgressMessages');
+const UserCancelledExport = require('./errors/UserCancelledExport');
 
 /**
  * Interface for all data exports
@@ -266,7 +267,7 @@ class FileExportManager {
               electron = require('electron');
             }
 
-            const dialog = electron.dialog;
+            const { dialog } = electron;
             const browserWindow = first(electron.BrowserWindow.getAllWindows());
 
             dialog.showSaveDialog(
@@ -284,7 +285,7 @@ class FileExportManager {
 
                 rename(zipLocation, filePath)
                   .then(() => {
-                    const shell = electron.shell;
+                    const { shell } = electron;
                     shell.showItemInFolder(filePath);
                     resolve();
                   })

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -23,7 +23,7 @@ const { verifySessionVariables } = require('./utils/general');
 const { isCordova, isElectron } = require('./utils/Environment');
 const archive = require('./utils/archive');
 const { ExportError, ErrorMessages } = require('./errors/ExportError');
-const ProgressMessages = require('./ProgressMessages');
+const { ProgressMessages } = require('./ProgressMessages');
 const { UserCancelledExport } = require('./errors/UserCancelledExport');
 
 /**

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -277,7 +277,10 @@ class FileExportManager {
               },
             )
               .then(({ canceled, filePath }) => {
-                if (canceled) { resolve(); }
+                if (canceled) {
+                  this.emit('cancelled', ProgressMessages.Cancelled);
+                  resolve();
+                }
 
                 rename(zipLocation, filePath)
                   .then(() => {

--- a/src/ProgressMessages.js
+++ b/src/ProgressMessages.js
@@ -33,4 +33,4 @@ const ProgressMessages = {
   },
 };
 
-export default ProgressMessages;
+module.exports = ProgressMessages;

--- a/src/ProgressMessages.js
+++ b/src/ProgressMessages.js
@@ -31,6 +31,10 @@ const ProgressMessages = {
     progress: 100,
     statusText: 'Export finished.',
   },
+  Cancelled: {
+    progress: 100,
+    statusText: 'Export cancelled.',
+  },
 };
 
 module.exports = {

--- a/src/ProgressMessages.js
+++ b/src/ProgressMessages.js
@@ -33,4 +33,7 @@ const ProgressMessages = {
   },
 };
 
-module.exports = ProgressMessages;
+module.exports = {
+  default: ProgressMessages,
+  ProgressMessages,
+}

--- a/src/ProgressMessages.js
+++ b/src/ProgressMessages.js
@@ -37,7 +37,4 @@ const ProgressMessages = {
   },
 };
 
-module.exports = {
-  default: ProgressMessages,
-  ProgressMessages,
-}
+module.exports = ProgressMessages;

--- a/src/errors/ExportError.js
+++ b/src/errors/ExportError.js
@@ -5,14 +5,14 @@
  * API services can use this to distinguish between client input errors and
  * unexpected (server) errors.
  */
-export class ExportError extends Error {
+class ExportError extends Error {
   constructor(message) {
     super(message);
     this.name = 'ExportError';
   }
 }
 
-export const ErrorMessages = {
+const ErrorMessages = {
   NoTmpFS: 'Couldn\'t create a temporary directory for the export.',
   EmptyFilelist: 'Empty filelist',
   FilelistNotSingular: 'Multiple files must be uploaded separately',
@@ -27,4 +27,9 @@ export const ErrorMessages = {
   NotFound: 'Not found',
   NothingToExport: 'No data available to export',
   VerificationFailed: 'Request verification failed',
+};
+
+module.exports = {
+  ExportError,
+  ErrorMessages,
 };

--- a/src/errors/UserCancelledExport.js
+++ b/src/errors/UserCancelledExport.js
@@ -6,4 +6,7 @@ class UserCancelledExport extends Error {
   }
 }
 
-export default UserCancelledExport;
+module.exports = {
+  default: UserCancelledExport,
+  UserCancelledExport,
+};

--- a/src/errors/UserCancelledExport.js
+++ b/src/errors/UserCancelledExport.js
@@ -6,7 +6,4 @@ class UserCancelledExport extends Error {
   }
 }
 
-module.exports = {
-  default: UserCancelledExport,
-  UserCancelledExport,
-};
+module.exports = UserCancelledExport;

--- a/src/exportFile.js
+++ b/src/exportFile.js
@@ -7,7 +7,7 @@ const {
 const { isCordova, isElectron } = require('./utils/Environment');
 const { getFormatterClass } = require('./utils/getFormatterClass');
 const { ExportError } = require('./errors/ExportError');
-const { UserCancelledExport } = require('./errors/UserCancelledExport');
+const UserCancelledExport = require('./errors/UserCancelledExport');
 
 /**
  * Export a single (CSV or graphml) file

--- a/src/exportFile.js
+++ b/src/exportFile.js
@@ -7,7 +7,7 @@ const {
 const { isCordova, isElectron } = require('./utils/Environment');
 const { getFormatterClass } = require('./utils/getFormatterClass');
 const { ExportError } = require('./errors/ExportError');
-const UserCancelledExport = require('./errors/UserCancelledExport');
+const { UserCancelledExport } = require('./errors/UserCancelledExport');
 
 /**
  * Export a single (CSV or graphml) file

--- a/src/exportFile.js
+++ b/src/exportFile.js
@@ -5,7 +5,7 @@ const {
   makeFilename,
 } = require('./utils/general');
 const { isCordova, isElectron } = require('./utils/Environment');
-const getFormatterClass = require('./utils/getFormatterClass');
+const { getFormatterClass } = require('./utils/getFormatterClass');
 const { ExportError } = require('./errors/ExportError');
 const UserCancelledExport = require('./errors/UserCancelledExport');
 

--- a/src/exportFile.js
+++ b/src/exportFile.js
@@ -5,7 +5,7 @@ const {
   makeFilename,
 } = require('./utils/general');
 const { isCordova, isElectron } = require('./utils/Environment');
-const { getFormatterClass } = require('./utils/getFormatterClass');
+const getFormatterClass = require('./utils/getFormatterClass');
 const { ExportError } = require('./errors/ExportError');
 const UserCancelledExport = require('./errors/UserCancelledExport');
 

--- a/src/exportFile.js
+++ b/src/exportFile.js
@@ -1,13 +1,13 @@
 /* eslint-disable global-require */
-import { createWriteStream } from './utils/filesystem';
-import {
+const { createWriteStream } = require('./utils/filesystem');
+const {
   getFileExtension,
   makeFilename,
-} from './utils/general';
-import { isCordova, isElectron } from './utils/Environment';
-import getFormatterClass from './utils/getFormatterClass';
-import { ExportError } from './errors/ExportError';
-import UserCancelledExport from './errors/UserCancelledExport';
+} = require('./utils/general');
+const { isCordova, isElectron } = require('./utils/Environment');
+const getFormatterClass = require('./utils/getFormatterClass');
+const { ExportError } = require('./errors/ExportError');
+const UserCancelledExport = require('./errors/UserCancelledExport');
 
 /**
  * Export a single (CSV or graphml) file
@@ -93,4 +93,4 @@ const exportFile = (
   return pathPromise;
 };
 
-export default exportFile;
+module.exports = exportFile;

--- a/src/formatters/csv/__tests__/attribute-list-test.js
+++ b/src/formatters/csv/__tests__/attribute-list-test.js
@@ -2,7 +2,7 @@
 
 import { makeWriteableStream } from '../../../../config/setupTestEnv';
 import { mockCodebook, mockExportOptions } from '../../../../config/mockObjects';
-import AttributeListFormatter, { asAttributeList, toCSVStream } from '../attribute-list';
+import { AttributeListFormatter, asAttributeList, toCSVStream } from '../attribute-list';
 import { entityPrimaryKeyProperty, entityAttributesProperty, egoProperty, exportIDProperty, ncUUIDProperty } from '../../../utils/reservedAttributes';
 
 const node = {

--- a/src/formatters/csv/__tests__/edge-list-test.js
+++ b/src/formatters/csv/__tests__/edge-list-test.js
@@ -2,7 +2,7 @@
 import { makeWriteableStream } from '../../../../config/setupTestEnv';
 import { mockCodebook, mockExportOptions } from '../../../../config/mockObjects';
 import { entityPrimaryKeyProperty, edgeSourceProperty, edgeTargetProperty, entityAttributesProperty, exportIDProperty, egoProperty, ncUUIDProperty, ncSourceUUID, ncTargetUUID } from '../../../utils/reservedAttributes';
-import EdgeListFormatter, { asEdgeList, toCSVStream } from '../edge-list';
+import { EdgeListFormatter, asEdgeList, toCSVStream } from '../edge-list';
 
 const nodes = [
   { [entityPrimaryKeyProperty]: 1 },

--- a/src/formatters/csv/__tests__/ego-list-test.js
+++ b/src/formatters/csv/__tests__/ego-list-test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { makeWriteableStream } from '../../../../config/setupTestEnv';
 import { mockCodebook, mockExportOptions } from '../../../../config/mockObjects';
-import EgoListFormatter, { asEgoAndSessionVariablesList, toCSVStream } from '../ego-list';
+import { EgoListFormatter, asEgoAndSessionVariablesList, toCSVStream } from '../ego-list';
 import { entityPrimaryKeyProperty, entityAttributesProperty, egoProperty, caseProperty, ncSessionProperty, ncProtocolNameProperty, sessionStartTimeProperty, sessionFinishTimeProperty, sessionExportTimeProperty, protocolName, ncCaseProperty, sessionProperty } from '../../../utils/reservedAttributes';
 
 const ego = {

--- a/src/formatters/csv/__tests__/matrix-test.js
+++ b/src/formatters/csv/__tests__/matrix-test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { makeWriteableStream } from '../../../../config/setupTestEnv';
-import AdjacencyMatrixFormatter, { asAdjacencyMatrix } from '../matrix';
+import { AdjacencyMatrixFormatter, asAdjacencyMatrix } from '../matrix';
 import { ncSourceUUID, ncTargetUUID } from '../../../utils/reservedAttributes';
 
 const mockNetwork = edges => ({

--- a/src/formatters/csv/attribute-list.js
+++ b/src/formatters/csv/attribute-list.js
@@ -1,16 +1,16 @@
-import {
+const {
   entityAttributesProperty,
   egoProperty,
   entityPrimaryKeyProperty,
   exportIDProperty,
   ncUUIDProperty,
-} from '../../utils/reservedAttributes';
-import { processEntityVariables } from '../network';
+} = require('../../utils/reservedAttributes');
+const { processEntityVariables } = require('../network');
 
 const { Readable } = require('stream');
 const { sanitizedCellValue, csvEOL } = require('./csv');
 
-export const asAttributeList = (network, codebook, exportOptions) => {
+const asAttributeList = (network, codebook, exportOptions) => {
   const processedNodes = (network.nodes || []).map((node) => {
     if (codebook && codebook.node[node.type]) {
       return processEntityVariables(node, 'node', codebook, exportOptions);
@@ -51,7 +51,7 @@ const getPrintableAttribute = (attribute) => {
 /**
  * @return {Object} an abort controller; call the attached abort() method as needed.
  */
-export const toCSVStream = (nodes, outStream) => {
+const toCSVStream = (nodes, outStream) => {
   const totalRows = nodes.length;
   const attrNames = attributeHeaders(nodes);
   let headerWritten = false;
@@ -107,4 +107,9 @@ class AttributeListFormatter {
   }
 }
 
-export default AttributeListFormatter;
+module.exports = {
+  default: AttributeListFormatter,
+  AttributeListFormatter,
+  asAttributeList,
+  toCSVStream,
+};

--- a/src/formatters/csv/attribute-list.js
+++ b/src/formatters/csv/attribute-list.js
@@ -1,3 +1,4 @@
+const { Readable } = require('stream');
 const {
   entityAttributesProperty,
   egoProperty,
@@ -6,8 +7,6 @@ const {
   ncUUIDProperty,
 } = require('../../utils/reservedAttributes');
 const { processEntityVariables } = require('../network');
-
-const { Readable } = require('stream');
 const { sanitizedCellValue, csvEOL } = require('./csv');
 
 const asAttributeList = (network, codebook, exportOptions) => {
@@ -108,7 +107,6 @@ class AttributeListFormatter {
 }
 
 module.exports = {
-  default: AttributeListFormatter,
   AttributeListFormatter,
   asAttributeList,
   toCSVStream,

--- a/src/formatters/csv/edge-list.js
+++ b/src/formatters/csv/edge-list.js
@@ -1,4 +1,4 @@
-import {
+const {
   entityAttributesProperty,
   egoProperty,
   entityPrimaryKeyProperty,
@@ -6,8 +6,8 @@ import {
   ncSourceUUID,
   ncTargetUUID,
   ncUUIDProperty,
-} from '../../utils/reservedAttributes';
-import { processEntityVariables } from '../network';
+} = require('../../utils/reservedAttributes');
+const { processEntityVariables } = require('../network');
 
 const { Readable } = require('stream');
 
@@ -33,7 +33,7 @@ const { sanitizedCellValue, csvEOL } = require('./csv');
  *                            default: false
  * @return {Array} the edges list
  */
-export const asEdgeList = (network, codebook, exportOptions) => {
+const asEdgeList = (network, codebook, exportOptions) => {
   const directed = exportOptions.globalOptions.useDirectedEdges;
   const processedEdges = (network.edges || []).map(edge => processEntityVariables(edge, 'edge', codebook, exportOptions));
 
@@ -99,7 +99,7 @@ const getPrintableAttribute = (attribute) => {
  *
  * @return {Object} an abort controller; call the attached abort() method as needed.
  */
-export const toCSVStream = (edges, outStream) => {
+const toCSVStream = (edges, outStream) => {
   const totalChunks = edges.length;
   let chunkContent;
   let chunkIndex = 0;
@@ -159,4 +159,9 @@ class EdgeListFormatter {
   }
 }
 
-export default EdgeListFormatter;
+module.exports = {
+  default: EdgeListFormatter,
+  EdgeListFormatter,
+  asEdgeList,
+  toCSVStream,
+};

--- a/src/formatters/csv/edge-list.js
+++ b/src/formatters/csv/edge-list.js
@@ -1,3 +1,4 @@
+const { Readable } = require('stream');
 const {
   entityAttributesProperty,
   egoProperty,
@@ -8,9 +9,6 @@ const {
   ncUUIDProperty,
 } = require('../../utils/reservedAttributes');
 const { processEntityVariables } = require('../network');
-
-const { Readable } = require('stream');
-
 const { sanitizedCellValue, csvEOL } = require('./csv');
 
 /**
@@ -160,7 +158,6 @@ class EdgeListFormatter {
 }
 
 module.exports = {
-  default: EdgeListFormatter,
   EdgeListFormatter,
   asEdgeList,
   toCSVStream,

--- a/src/formatters/csv/ego-list.js
+++ b/src/formatters/csv/ego-list.js
@@ -1,4 +1,4 @@
-import {
+const {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
   caseProperty,
@@ -11,13 +11,13 @@ import {
   ncCaseProperty,
   ncSessionProperty,
   ncProtocolNameProperty,
-} from '../../utils/reservedAttributes';
-import { processEntityVariables } from '../network';
+} = require('../../utils/reservedAttributes');
+const { processEntityVariables } = require('../network');
 
 const { Readable } = require('stream');
 const { sanitizedCellValue, csvEOL } = require('./csv');
 
-export const asEgoAndSessionVariablesList = (network, codebook, exportOptions) => {
+const asEgoAndSessionVariablesList = (network, codebook, exportOptions) => {
   if (exportOptions.globalOptions.unifyNetworks) {
     // If unified networks is enabled, network.ego is an object keyed by sessionID.
     return Object.keys(network.ego).map(sessionID => (
@@ -79,7 +79,7 @@ const getPrintableAttribute = (attribute) => {
 /**
  * @return {Object} an abort controller; call the attached abort() method as needed.
  */
-export const toCSVStream = (egos, outStream) => {
+const toCSVStream = (egos, outStream) => {
   const totalRows = egos.length;
   const attrNames = attributeHeaders(egos);
   let headerWritten = false;
@@ -139,4 +139,9 @@ class EgoListFormatter {
   }
 }
 
-export default EgoListFormatter;
+module.exports = {
+  default: EgoListFormatter,
+  EgoListFormatter,
+  asEgoAndSessionVariablesList,
+  toCSVStream,
+};

--- a/src/formatters/csv/ego-list.js
+++ b/src/formatters/csv/ego-list.js
@@ -1,3 +1,4 @@
+const { Readable } = require('stream');
 const {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
@@ -13,8 +14,6 @@ const {
   ncProtocolNameProperty,
 } = require('../../utils/reservedAttributes');
 const { processEntityVariables } = require('../network');
-
-const { Readable } = require('stream');
 const { sanitizedCellValue, csvEOL } = require('./csv');
 
 const asEgoAndSessionVariablesList = (network, codebook, exportOptions) => {
@@ -140,7 +139,6 @@ class EgoListFormatter {
 }
 
 module.exports = {
-  default: EgoListFormatter,
   EgoListFormatter,
   asEgoAndSessionVariablesList,
   toCSVStream,

--- a/src/formatters/csv/matrix.js
+++ b/src/formatters/csv/matrix.js
@@ -252,7 +252,6 @@ class AdjacencyMatrixFormatter {
 }
 
 module.exports = {
-  default: AdjacencyMatrixFormatter,
   AdjacencyMatrixFormatter,
   asAdjacencyMatrix,
 };

--- a/src/formatters/csv/matrix.js
+++ b/src/formatters/csv/matrix.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-bitwise */
 /* eslint space-infix-ops: ["error", {"int32Hint": true}] */
-import { Readable } from 'stream';
-import { entityPrimaryKeyProperty, ncSourceUUID, ncTargetUUID } from '../../utils/reservedAttributes';
-import { csvEOL } from './csv';
+const { Readable } = require('stream');
+const { entityPrimaryKeyProperty, ncSourceUUID, ncTargetUUID } = require('../../utils/reservedAttributes');
+const { csvEOL } = require('./csv');
 
 /**
  * An opaque reprensentation of an adjacency matrix with binary values (edge is present/absent).
@@ -235,7 +235,7 @@ class AdjacencyMatrix {
   }
 }
 
-export const asAdjacencyMatrix = (network, directed = false) => {
+const asAdjacencyMatrix = (network, directed = false) => {
   const adjacencyMatrix = new AdjacencyMatrix(network);
   adjacencyMatrix.calculateEdges(directed);
   return adjacencyMatrix;
@@ -251,4 +251,8 @@ class AdjacencyMatrixFormatter {
   }
 }
 
-export default AdjacencyMatrixFormatter;
+module.exports = {
+  default: AdjacencyMatrixFormatter,
+  AdjacencyMatrixFormatter,
+  asAdjacencyMatrix,
+};

--- a/src/formatters/graphml/GraphMLFormatter.js
+++ b/src/formatters/graphml/GraphMLFormatter.js
@@ -1,5 +1,5 @@
 const { Readable } = require('stream');
-const { graphMLGenerator } = require('./createGraphML');
+const graphMLGenerator = require('./createGraphML');
 
 /** Class providing a graphML formatter. */
 class GraphMLFormatter {
@@ -78,7 +78,4 @@ class GraphMLFormatter {
   }
 }
 
-module.exports = {
-  default: GraphMLFormatter,
-  GraphMLFormatter,
-};
+module.exports = GraphMLFormatter;

--- a/src/formatters/graphml/GraphMLFormatter.js
+++ b/src/formatters/graphml/GraphMLFormatter.js
@@ -1,5 +1,5 @@
 const { Readable } = require('stream');
-const graphMLGenerator = require('./createGraphML');
+const { graphMLGenerator } = require('./createGraphML');
 
 /** Class providing a graphML formatter. */
 class GraphMLFormatter {

--- a/src/formatters/graphml/GraphMLFormatter.js
+++ b/src/formatters/graphml/GraphMLFormatter.js
@@ -1,5 +1,5 @@
-import { Readable } from 'stream';
-import graphMLGenerator from './createGraphML';
+const { Readable } = require('stream');
+const graphMLGenerator = require('./createGraphML');
 
 /** Class providing a graphML formatter. */
 class GraphMLFormatter {
@@ -78,4 +78,7 @@ class GraphMLFormatter {
   }
 }
 
-export default GraphMLFormatter;
+module.exports = {
+  default: GraphMLFormatter,
+  GraphMLFormatter,
+};

--- a/src/formatters/graphml/createGraphML.js
+++ b/src/formatters/graphml/createGraphML.js
@@ -1,14 +1,14 @@
-import { findKey, includes, groupBy } from 'lodash';
-import jsSHA from 'jssha/dist/sha1';
-import {
+const { findKey, includes, groupBy } = require('lodash');
+const jsSHA = require('jssha/dist/sha1');
+const {
   getEntityAttributes,
   createDataElement,
   getGraphMLTypeForKey,
   getAttributePropertyFromCodebook,
   formatXml,
-} from './helpers';
-import { VariableType } from '../../utils/protocol-consts';
-import {
+} = require('./helpers');
+const { VariableType } = require('../../utils/protocol-consts');
+const {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
   caseProperty,
@@ -25,7 +25,7 @@ import {
   edgeTargetProperty,
   ncTypeProperty,
   ncUUIDProperty,
-} from '../../utils/reservedAttributes';
+} = require('../../utils/reservedAttributes');
 
 // In a browser process, window provides a globalContext;
 // in an electron main process, we can inject required globals
@@ -644,4 +644,7 @@ function* graphMLGenerator(network, codebook, exportOptions) {
   yield xmlFooter;
 }
 
-export default graphMLGenerator;
+module.exports = {
+  default: graphMLGenerator,
+  graphMLGenerator,
+};

--- a/src/formatters/graphml/createGraphML.js
+++ b/src/formatters/graphml/createGraphML.js
@@ -7,7 +7,7 @@ const {
   getAttributePropertyFromCodebook,
   formatXml,
 } = require('./helpers');
-const { VariableType } = require('../../utils/protocol-consts');
+const VariableType = require('../../utils/protocol-consts');
 const {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
@@ -644,7 +644,4 @@ function* graphMLGenerator(network, codebook, exportOptions) {
   yield xmlFooter;
 }
 
-module.exports = {
-  default: graphMLGenerator,
-  graphMLGenerator,
-};
+module.exports = graphMLGenerator;

--- a/src/formatters/graphml/helpers.js
+++ b/src/formatters/graphml/helpers.js
@@ -1,11 +1,11 @@
-import { isNil } from 'lodash';
-import { VariableType } from '../../utils/protocol-consts';
-import { entityAttributesProperty } from '../../utils/reservedAttributes';
+const { isNil } = require('lodash');
+const { VariableType } = require('../../utils/protocol-consts');
+const { entityAttributesProperty } = require('../../utils/reservedAttributes');
 
-export const getEntityAttributes = node => (node && node[entityAttributesProperty]) || {};
+const getEntityAttributes = node => (node && node[entityAttributesProperty]) || {};
 
 // Gephi does not support long lines in graphML, meaning we need to "beautify" the output
-export const formatXml = (xml, tab = '\t') => { // tab = optional indent value, default is tab (\t)
+const formatXml = (xml, tab = '\t') => { // tab = optional indent value, default is tab (\t)
   let formatted = '';
   let indent = '';
 
@@ -17,7 +17,7 @@ export const formatXml = (xml, tab = '\t') => { // tab = optional indent value, 
   return formatted.substring(1, formatted.length - 3);
 };
 
-export const VariableTypeValues = Object.freeze(Object.values(VariableType));
+const VariableTypeValues = Object.freeze(Object.values(VariableType));
 
 /**
  * For a given key, return a valid Graphml data 'type' for encoding
@@ -32,7 +32,7 @@ export const VariableTypeValues = Object.freeze(Object.values(VariableType));
  * @param {*} data
  * @param {*} key
  */
-export const getGraphMLTypeForKey = (data, key) => (
+const getGraphMLTypeForKey = (data, key) => (
   data.reduce((result, value) => {
     const attrs = getEntityAttributes(value);
     if (isNil(attrs[key])) return result;
@@ -61,7 +61,7 @@ export const getGraphMLTypeForKey = (data, key) => (
  * @param {*} entity
  * @param {*} key
  */
-export const getVariableInfo = (codebook, type, entity, key) => (
+const getVariableInfo = (codebook, type, entity, key) => (
   codebook[type]
   && codebook[type][entity.type]
   && codebook[type][entity.type].variables
@@ -74,7 +74,7 @@ export const getVariableInfo = (codebook, type, entity, key) => (
  * @param {*} type
  * @param {*} key
  */
-export const getEgoVariableInfo = (codebook, key) => (
+const getEgoVariableInfo = (codebook, key) => (
   codebook.ego
   && codebook.ego.variables
   && codebook.ego.variables[key]
@@ -87,7 +87,7 @@ export const getEgoVariableInfo = (codebook, key) => (
  * @param {*} element
  * @param {*} key
  */
-export const codebookExists = (codebook, type, element, key) => {
+const codebookExists = (codebook, type, element, key) => {
   const variableInfo = getVariableInfo(codebook, type, element, key);
   return variableInfo && variableInfo.type && VariableTypeValues.includes(variableInfo.type);
 };
@@ -100,7 +100,7 @@ export const codebookExists = (codebook, type, element, key) => {
  * @param {*} key key within element to select
  * @param {*} variableAttribute property of key to return
  */
-export const getAttributePropertyFromCodebook = (codebook, type, element, key, attributeProperty = 'type') => {
+const getAttributePropertyFromCodebook = (codebook, type, element, key, attributeProperty = 'type') => {
   if (type === 'ego') {
     const variableInfo = getEgoVariableInfo(codebook, key);
     return variableInfo && variableInfo[attributeProperty];
@@ -109,7 +109,7 @@ export const getAttributePropertyFromCodebook = (codebook, type, element, key, a
   return variableInfo && variableInfo[attributeProperty];
 };
 
-export const createElement = (xmlDoc, tagName, attrs = {}, child = null) => {
+const createElement = (xmlDoc, tagName, attrs = {}, child = null) => {
   const element = xmlDoc.createElement(tagName);
   Object.entries(attrs).forEach(([key, val]) => {
     element.setAttribute(key, val);
@@ -120,4 +120,17 @@ export const createElement = (xmlDoc, tagName, attrs = {}, child = null) => {
   return element;
 };
 
-export const createDataElement = (xmlDoc, attributes, text) => createElement(xmlDoc, 'data', attributes, xmlDoc.createTextNode(text));
+const createDataElement = (xmlDoc, attributes, text) => createElement(xmlDoc, 'data', attributes, xmlDoc.createTextNode(text));
+
+module.exports = {
+  codebookExists,
+  createDataElement,
+  createElement,
+  formatXml,
+  getAttributePropertyFromCodebook,
+  getEgoVariableInfo,
+  getEntityAttributes,
+  getGraphMLTypeForKey,
+  getVariableInfo,
+  VariableTypeValues,
+};

--- a/src/formatters/graphml/helpers.js
+++ b/src/formatters/graphml/helpers.js
@@ -1,5 +1,5 @@
 const { isNil } = require('lodash');
-const { VariableType } = require('../../utils/protocol-consts');
+const VariableType = require('../../utils/protocol-consts');
 const { entityAttributesProperty } = require('../../utils/reservedAttributes');
 
 const getEntityAttributes = node => (node && node[entityAttributesProperty]) || {};

--- a/src/formatters/network.js
+++ b/src/formatters/network.js
@@ -208,11 +208,11 @@ const unionOfNetworks = sessionsByProtocol => Object.keys(sessionsByProtocol)
     };
   }, {});
 
-  module.exports = {
-    processEntityVariables,
-    insertNetworkEgo,
-    insertEgoIntoSessionNetworks,
-    partitionNetworkByType,
-    resequenceIds,
-    unionOfNetworks,
-  };
+module.exports = {
+  processEntityVariables,
+  insertNetworkEgo,
+  insertEgoIntoSessionNetworks,
+  partitionNetworkByType,
+  resequenceIds,
+  unionOfNetworks,
+};

--- a/src/formatters/network.js
+++ b/src/formatters/network.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import { includes } from 'lodash';
-import {
+const { includes } = require('lodash');
+const {
   entityPrimaryKeyProperty,
   sessionProperty,
   egoProperty,
@@ -9,13 +9,13 @@ import {
   ncTargetUUID,
   edgeSourceProperty,
   edgeTargetProperty,
-} from '../utils/reservedAttributes';
-import { getEntityAttributes } from '../utils/general';
-import { getAttributePropertyFromCodebook } from './graphml/helpers';
+} = require('../utils/reservedAttributes');
+const { getEntityAttributes } = require('../utils/general');
+const { getAttributePropertyFromCodebook } = require('./graphml/helpers');
 
 // Determine which variables to include
 // TODO: Move this to CSV formatter, since only CSV uses it
-export const processEntityVariables = (entity, entityType, codebook, exportOptions) => ({
+const processEntityVariables = (entity, entityType, codebook, exportOptions) => ({
   ...entity,
   attributes: Object.keys(getEntityAttributes(entity)).reduce(
     (accumulatedAttributes, attributeUUID) => {
@@ -65,7 +65,7 @@ export const processEntityVariables = (entity, entityType, codebook, exportOptio
 
 // Iterates a network, and adds an attribute to nodes and edges
 // that references the ego ID that nominated it
-export const insertNetworkEgo = session => (
+const insertNetworkEgo = session => (
   {
     ...session,
     nodes: session.nodes.map(node => (
@@ -77,7 +77,7 @@ export const insertNetworkEgo = session => (
   }
 );
 
-export const insertEgoIntoSessionNetworks = sessions => (
+const insertEgoIntoSessionNetworks = sessions => (
   sessions.map(session => insertNetworkEgo(session))
 );
 
@@ -92,7 +92,7 @@ export const insertEgoIntoSessionNetworks = sessions => (
  * @return {Array} An array of networks, partitioned by type. Each network object is decorated
  *                 with an additional `partitionEntity` prop to facilitate format naming.
  */
-export const partitionNetworkByType = (codebook, session, format) => {
+const partitionNetworkByType = (codebook, session, format) => {
   const getEntityName = (uuid, type) => codebook[type][uuid].name;
 
   switch (format) {
@@ -143,7 +143,7 @@ export const partitionNetworkByType = (codebook, session, format) => {
 
 // Iterates sessions and adds an automatically incrementing counter to
 // allow for human readable IDs
-export const resequenceIds = (sessions) => {
+const resequenceIds = (sessions) => {
   let resequencedId = 0;
   const IDLookupMap = {}; // Create a lookup object { [oldID] -> [incrementedID] }
   const resequencedEntities = sessions.map(session => ({
@@ -180,7 +180,7 @@ export const resequenceIds = (sessions) => {
 // Result is a SINGLE session, with MULTIPLE ego and sessionVariables
 // We add the sessionID to each entity so that we can groupBy on it within
 // the exporter to reconstruct the sessions.
-export const unionOfNetworks = sessionsByProtocol => Object.keys(sessionsByProtocol)
+const unionOfNetworks = sessionsByProtocol => Object.keys(sessionsByProtocol)
   .reduce((sessions, protocolUUID) => {
     const protocolSessions = sessionsByProtocol[protocolUUID]
       .reduce((union, session) => ({
@@ -207,3 +207,12 @@ export const unionOfNetworks = sessionsByProtocol => Object.keys(sessionsByProto
       [protocolUUID]: Array(protocolSessions),
     };
   }, {});
+
+  module.exports = {
+    processEntityVariables,
+    insertNetworkEgo,
+    insertEgoIntoSessionNetworks,
+    partitionNetworkByType,
+    resequenceIds,
+    unionOfNetworks,
+  };

--- a/src/utils/Environment.js
+++ b/src/utils/Environment.js
@@ -1,17 +1,22 @@
-import environments from './environments';
+const environments = require('./environments');
 
-export const isElectron = () => !!window.electron || !!window.require;
+const isElectron = () => !!window.electron || !!window.require;
 
-const os = (window.require && window.require('os')) || window.os;
-export const isMacOS = () => isElectron && os.platform() === 'darwin';
+if (typeof window !== 'undefined' && window) {
+  const os = (window.require && window.require('os')) || window.os;
+} else {
+  const os = require('os');
+}
 
-export const isWindows = () => isElectron && os.platform() === 'win32';
+const isMacOS = () => isElectron && os.platform() === 'darwin';
 
-export const isLinux = () => isElectron && os.platform() === 'linux';
+const isWindows = () => isElectron && os.platform() === 'win32';
 
-export const isCordova = () => !!window.cordova;
+const isLinux = () => isElectron && os.platform() === 'linux';
 
-export const isWeb = () => (!isCordova() && !isElectron());
+const isCordova = () => !!window.cordova;
+
+const isWeb = () => (!isCordova() && !isElectron());
 
 const getEnvironment = () => {
   if (isCordova()) return environments.CORDOVA;
@@ -23,4 +28,12 @@ const inEnvironment = tree =>
   (...args) =>
     tree(getEnvironment())(...args);
 
-export default inEnvironment;
+module.exports = {
+  default: inEnvironment,
+  inEnvironment,
+  isCordova,
+  isLinux,
+  isMacOS,
+  isWeb,
+  isWindows,
+};

--- a/src/utils/Environment.js
+++ b/src/utils/Environment.js
@@ -1,11 +1,24 @@
 const environments = require('./environments');
 
-const isElectron = () => !!window.electron || !!window.require;
-
+let hasWindow = false;
 if (typeof window !== 'undefined' && window) {
-  const os = (window.require && window.require('os')) || window.os;
+  hasWindow = true;
+}
+
+let isElectron;
+if (hasWindow) {
+  isElectron = () => !!window.electron || !!window.require;
 } else {
-  const os = require('os');
+  // if no window object assume we are in nodejs environment (Electron main)
+  isElectron = () => true;
+}
+
+let os;
+
+if (hasWindow) {
+  os = (window.require && window.require('os')) || window.os;
+} else {
+  os = require('os');
 }
 
 const isMacOS = () => isElectron && os.platform() === 'darwin';
@@ -14,7 +27,13 @@ const isWindows = () => isElectron && os.platform() === 'win32';
 
 const isLinux = () => isElectron && os.platform() === 'linux';
 
-const isCordova = () => !!window.cordova;
+let isCordova;
+if (hasWindow) {
+  isCordova = () => !!window.cordova;
+} else {
+  // if no window object assume we are in nodejs environment (Electron main)
+  isCordova = () => false;
+}
 
 const isWeb = () => (!isCordova() && !isElectron());
 
@@ -32,6 +51,7 @@ module.exports = {
   default: inEnvironment,
   inEnvironment,
   isCordova,
+  isElectron,
   isLinux,
   isMacOS,
   isWeb,

--- a/src/utils/Environment.js
+++ b/src/utils/Environment.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const environments = require('./environments');
 
 let hasWindow = false;
@@ -48,8 +49,8 @@ const inEnvironment = tree =>
     tree(getEnvironment())(...args);
 
 module.exports = {
-  default: inEnvironment,
   inEnvironment,
+  getEnvironment,
   isCordova,
   isElectron,
   isLinux,

--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -1,10 +1,9 @@
-const { default: getEnvironment, isElectron, isCordova } = require('./Environment');
-const { resolveFileSystemUrl, splitUrl, readFile, newFile, makeFileWriter } = require('./filesystem');
-
 const fs = require('fs');
 const path = require('path');
 const archiver = require('archiver');
 const JSZip = require('jszip');
+const { getEnvironment, isElectron, isCordova } = require('./Environment');
+const { resolveFileSystemUrl, splitUrl, readFile, newFile, makeFileWriter } = require('./filesystem');
 
 // const zlibFastestCompression = 1;
 // const zlibBestCompression = 9;

--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -65,7 +65,7 @@ const archiveCordova = (sourcePaths, targetFileName, updateCallback) => {
 
   const promisedExports = sourcePaths.map(
     (sourcePath) => {
-      const [filename] = splitUrl(sourcePath);
+      const [, filename] = splitUrl(sourcePath);
       return readFile(sourcePath)
         .then(fileContent => zip.file(filename, fileContent));
     },

--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -1,5 +1,5 @@
-import getEnvironment, { isElectron, isCordova } from './Environment';
-import { resolveFileSystemUrl, splitUrl, readFile, newFile, makeFileWriter } from './filesystem';
+const { default: getEnvironment, isElectron, isCordova } = require('./Environment');
+const { resolveFileSystemUrl, splitUrl, readFile, newFile, makeFileWriter } = require('./filesystem');
 
 const fs = require('fs');
 const path = require('path');
@@ -118,4 +118,4 @@ const archive = (sourcePaths, tempDir, updateCallback) => {
 };
 
 // This is adapted from Architect; consider using `extract` as well
-export default archive;
+module.exports = archive;

--- a/src/utils/environments.js
+++ b/src/utils/environments.js
@@ -3,9 +3,9 @@ const ELECTRON = Symbol('ENVIRONMENT/ELECTRON');
 const WEB = Symbol('ENVIRONMENT/WEB');
 const UNKNOWN = Symbol('ENVIRONMENT/UNKNOWN');
 
-export default {
+module.exports = {
   CORDOVA,
   ELECTRON,
-  WEB,
   UNKNOWN,
+  WEB,
 };

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -1,11 +1,11 @@
 /* eslint-disable global-require */
 /* global FileWriter, FileError, cordova */
-import uuid from 'uuid/v4';
-import { Writable } from 'stream';
-import { trimChars } from 'lodash/fp';
-import environments from './environments';
-import { ExportError, ErrorMessages } from '../errors/ExportError';
-import inEnvironment, { isElectron, isCordova } from './Environment';
+const uuid = require('uuid/v4');
+const { Writable } = require('stream');
+const { trimChars } = require('lodash/fp');
+const environments = require('./environments');
+const { ExportError, ErrorMessages } = require('../errors/ExportError');
+const { inEnvironment, isElectron, isCordova } = require('./Environment');
 
 const { Buffer } = require('buffer/');
 
@@ -19,7 +19,7 @@ const resolveOrRejectWith = (resolve, reject) => (err, ...args) => {
   }
 };
 
-export const splitUrl = (targetPath) => {
+const splitUrl = (targetPath) => {
   const pathParts = trimPath(targetPath).split('/');
   const baseDirectory = `${pathParts.slice(0, -1).join('/')}/`;
   const directory = `${pathParts.slice(-1)}`;
@@ -100,7 +100,7 @@ const createDirectory = inEnvironment((environment) => {
  * @return {string} the directory (path) created
  */
 
-export const makeTempDir = () => {
+const makeTempDir = () => {
   const directoryName = `temp-export-${uuid()}`;
   let directoryPath;
   if (isElectron()) {
@@ -133,7 +133,7 @@ const userDataPath = inEnvironment((environment) => {
   throw new Error(`userDataPath() not available on platform ${environment}`);
 });
 
-export const getFileNativePath = inEnvironment((environment) => {
+const getFileNativePath = inEnvironment((environment) => {
   if (environment === environments.CORDOVA) {
     return filePath => new Promise((resolve, reject) => {
       window.resolveLocalFileSystemURL(filePath, (fileEntry) => {
@@ -166,7 +166,7 @@ const getFileEntry = (filename, fileSystem) => new Promise((resolve, reject) => 
 });
 
 
-export const getTempFileSystem = () => new Promise((resolve, reject) => {
+const getTempFileSystem = () => new Promise((resolve, reject) => {
   window.resolveLocalFileSystemURL(cordova.file.cacheDirectory, (dirEntry) => {
     resolve(dirEntry);
   }, error => reject(error));
@@ -209,19 +209,19 @@ const readFile = inEnvironment((environment) => {
   throw new Error(`readFile() not available on platform ${environment}`);
 });
 
-export const makeFileWriter = fileEntry =>
+const makeFileWriter = fileEntry =>
   new Promise((resolve, reject) => {
     fileEntry.createWriter(resolve, reject);
   });
 
-export const createReader = fileEntry => new Promise((resolve, reject) => {
+const createReader = fileEntry => new Promise((resolve, reject) => {
   fileEntry.file(
     file => resolve(file),
     err => reject(err),
   );
 });
 
-export const newFile = (directoryEntry, filename) =>
+const newFile = (directoryEntry, filename) =>
   new Promise((resolve, reject) => {
     directoryEntry.getFile(filename, { create: true }, resolve, reject);
   });
@@ -492,7 +492,7 @@ const writeStream = inEnvironment((environment) => {
 
 // Objective here is to abstract fs.createWriteStream.
 // Needs to return a writeable stream.
-export const createWriteStream = inEnvironment((environment) => {
+const createWriteStream = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
     const fs = require('fs');
 
@@ -672,20 +672,28 @@ const makeTmpDirCopy = inEnvironment((environment) => {
   throw new Error(`makeTmpDirCopy() not available on platform ${environment}`);
 });
 
-export {
-  getFileEntry,
-  userDataPath,
-  tempDataPath,
+module.exports = {
   appPath,
-  getNestedPaths,
-  ensurePathExists,
-  makeTmpDirCopy,
   createDirectory,
-  rename,
-  removeDirectory,
+  createReader,
+  createWriteStream,
+  ensurePathExists,
+  getFileEntry,
+  getFileNativePath,
+  getNestedPaths,
+  getTempFileSystem,
+  inSequence,
+  makeFileWriter,
+  makeTempDir,
+  makeTmpDirCopy,
+  newFile,
   readFile,
+  removeDirectory,
+  rename,
   resolveFileSystemUrl,
+  splitUrl,
+  tempDataPath,
+  userDataPath,
   writeFile,
   writeStream,
-  inSequence,
 };

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -34,7 +34,14 @@ const inSequence = (items, apply) =>
 
 const tempDataPath = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const electron = window.require('electron');
+    let electron;
+
+    if (typeof window !== 'undefined' && window) {
+      electron = window.require('electron');
+    } else {
+      // if no window object assume we are in nodejs environment (Electron main)
+      electron = require('electron');
+    }
 
     return () => (electron.app || electron.remote.app).getPath('temp');
   }
@@ -121,7 +128,14 @@ const makeTempDir = () => {
 
 const userDataPath = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const electron = window.require('electron');
+    let electron;
+
+    if (typeof window !== 'undefined' && window) {
+      electron = window.require('electron');
+    } else {
+      // if no window object assume we are in nodejs environment (Electron main)
+      electron = require('electron');
+    }
 
     return () => (electron.app || electron.remote.app).getPath('userData');
   }

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -3,11 +3,10 @@
 const uuid = require('uuid/v4');
 const { Writable } = require('stream');
 const { trimChars } = require('lodash/fp');
+const { Buffer } = require('buffer/');
 const environments = require('./environments');
 const { ExportError, ErrorMessages } = require('../errors/ExportError');
 const { inEnvironment, isElectron, isCordova } = require('./Environment');
-
-const { Buffer } = require('buffer/');
 
 const trimPath = trimChars('/ ');
 

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1,15 +1,15 @@
 
-import { ExportError, ErrorMessages } from '../errors/ExportError';
-import {
+const { ExportError, ErrorMessages } = require('../errors/ExportError');
+const {
   caseProperty,
   sessionProperty,
   remoteProtocolProperty,
   entityAttributesProperty,
   sessionExportTimeProperty,
-} from './reservedAttributes';
+} = require('./reservedAttributes');
 
 // Session vars should match https://github.com/codaco/graphml-schemas/blob/master/xmlns/1.0/graphml%2Bnetcanvas.xsd
-export const verifySessionVariables = (sessionVariables) => {
+const verifySessionVariables = (sessionVariables) => {
   if (
     !sessionVariables[caseProperty]
     || !sessionVariables[sessionProperty]
@@ -22,11 +22,11 @@ export const verifySessionVariables = (sessionVariables) => {
   return true;
 };
 
-export const getEntityAttributes = entity => (entity && entity[entityAttributesProperty]) || {};
+const getEntityAttributes = entity => (entity && entity[entityAttributesProperty]) || {};
 
-export const escapeFilePart = part => part.replace(/\W/g, '');
+const escapeFilePart = part => part.replace(/\W/g, '');
 
-export const makeFilename = (prefix, entityType, exportFormat, extension) => {
+const makeFilename = (prefix, entityType, exportFormat, extension) => {
   let name = prefix;
   if (extension !== `.${exportFormat}`) {
     name += name ? '_' : '';
@@ -38,7 +38,7 @@ export const makeFilename = (prefix, entityType, exportFormat, extension) => {
   return `${name}${extension}`;
 };
 
-export const extensions = {
+const extensions = {
   graphml: '.graphml',
   csv: '.csv',
 };
@@ -48,7 +48,7 @@ export const extensions = {
  * @param  {string} formatterType one of the `format`s
  * @return {string}
  */
-export const getFileExtension = (formatterType) => {
+const getFileExtension = (formatterType) => {
   switch (formatterType) {
     case 'graphml':
       return extensions.graphml;
@@ -62,4 +62,14 @@ export const getFileExtension = (formatterType) => {
   }
 };
 
-export const extensionPattern = new RegExp(`${Object.values(extensions).join('|')}$`);
+const extensionPattern = new RegExp(`${Object.values(extensions).join('|')}$`);
+
+module.exports = {
+  escapeFilePart,
+  extensionPattern,
+  extensions,
+  getEntityAttributes,
+  getFileExtension,
+  makeFilename,
+  verifySessionVariables,
+};

--- a/src/utils/getFormatterClass.js
+++ b/src/utils/getFormatterClass.js
@@ -1,8 +1,8 @@
-const AdjacencyMatrixFormatter = require('../formatters/csv/matrix');
-const AttributeListFormatter = require('../formatters/csv/attribute-list');
-const EgoListFormatter = require('../formatters/csv/ego-list');
-const EdgeListFormatter = require('../formatters/csv/edge-list');
-const GraphMLFormatter = require('../formatters/graphml/GraphMLFormatter');
+const { AdjacencyMatrixFormatter } = require('../formatters/csv/matrix');
+const { AttributeListFormatter } = require('../formatters/csv/attribute-list');
+const { EgoListFormatter } = require('../formatters/csv/ego-list');
+const { EdgeListFormatter } = require('../formatters/csv/edge-list');
+const { GraphMLFormatter } = require('../formatters/graphml/GraphMLFormatter');
 
 /**
  * Formatter factory

--- a/src/utils/getFormatterClass.js
+++ b/src/utils/getFormatterClass.js
@@ -1,8 +1,8 @@
-import AdjacencyMatrixFormatter from '../formatters/csv/matrix';
-import AttributeListFormatter from '../formatters/csv/attribute-list';
-import EgoListFormatter from '../formatters/csv/ego-list';
-import EdgeListFormatter from '../formatters/csv/edge-list';
-import GraphMLFormatter from '../formatters/graphml/GraphMLFormatter';
+const AdjacencyMatrixFormatter = require('../formatters/csv/matrix');
+const AttributeListFormatter = require('../formatters/csv/attribute-list');
+const EgoListFormatter = require('../formatters/csv/ego-list');
+const EdgeListFormatter = require('../formatters/csv/edge-list');
+const GraphMLFormatter = require('../formatters/graphml/GraphMLFormatter');
 
 /**
  * Formatter factory
@@ -26,4 +26,7 @@ const getFormatterClass = (formatterType) => {
   }
 };
 
-export default getFormatterClass;
+module.exports = {
+  default: getFormatterClass,
+  getFormatterClass,
+};

--- a/src/utils/getFormatterClass.js
+++ b/src/utils/getFormatterClass.js
@@ -2,7 +2,7 @@ const { AdjacencyMatrixFormatter } = require('../formatters/csv/matrix');
 const { AttributeListFormatter } = require('../formatters/csv/attribute-list');
 const { EgoListFormatter } = require('../formatters/csv/ego-list');
 const { EdgeListFormatter } = require('../formatters/csv/edge-list');
-const { GraphMLFormatter } = require('../formatters/graphml/GraphMLFormatter');
+const GraphMLFormatter = require('../formatters/graphml/GraphMLFormatter');
 
 /**
  * Formatter factory
@@ -26,7 +26,4 @@ const getFormatterClass = (formatterType) => {
   }
 };
 
-module.exports = {
-  default: getFormatterClass,
-  getFormatterClass,
-};
+module.exports = getFormatterClass;

--- a/src/utils/protocol-consts.js
+++ b/src/utils/protocol-consts.js
@@ -12,7 +12,4 @@ const VariableType = Object.freeze({
   datetime: 'datetime',
 });
 
-module.exports = {
-  default: VariableType,
-  VariableType,
-};
+module.exports = VariableType;

--- a/src/utils/protocol-consts.js
+++ b/src/utils/protocol-consts.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 // Docs: https://github.com/codaco/Network-Canvas/wiki/Variable-Types
 
-export const VariableType = Object.freeze({
+const VariableType = Object.freeze({
   boolean: 'boolean',
   text: 'text',
   number: 'number',
@@ -11,3 +11,8 @@ export const VariableType = Object.freeze({
   scalar: 'scalar',
   datetime: 'datetime',
 });
+
+module.exports = {
+  default: VariableType,
+  VariableType,
+};

--- a/src/utils/reservedAttributes.js
+++ b/src/utils/reservedAttributes.js
@@ -1,26 +1,50 @@
 // Model properties
-export const entityPrimaryKeyProperty = '_uid';
-export const entityAttributesProperty = 'attributes';
-export const edgeSourceProperty = 'from';
-export const edgeTargetProperty = 'to';
+const entityPrimaryKeyProperty = '_uid';
+const entityAttributesProperty = 'attributes';
+const edgeSourceProperty = 'from';
+const edgeTargetProperty = 'to';
 
 // Session variable properties
-export const caseProperty = 'caseId';
-export const sessionProperty = 'sessionId';
-export const protocolProperty = 'protocolUID';
-export const protocolName = 'protocolName';
-export const remoteProtocolProperty = 'remoteProtocolID';
-export const sessionStartTimeProperty = 'sessionStart';
-export const sessionFinishTimeProperty = 'sessionFinish';
-export const sessionExportTimeProperty = 'sessionExported';
+const caseProperty = 'caseId';
+const sessionProperty = 'sessionId';
+const protocolProperty = 'protocolUID';
+const protocolName = 'protocolName';
+const remoteProtocolProperty = 'remoteProtocolID';
+const sessionStartTimeProperty = 'sessionStart';
+const sessionFinishTimeProperty = 'sessionFinish';
+const sessionExportTimeProperty = 'sessionExported';
 
 // Export properties
-export const exportIDProperty = 'id'; // property for auto incrementing ID number
-export const egoProperty = 'networkCanvasEgoUUID';
-export const ncTypeProperty = 'networkCanvasType';
-export const ncProtocolNameProperty = 'networkCanvasProtocolName';
-export const ncCaseProperty = 'networkCanvasCaseID';
-export const ncSessionProperty = 'networkCanvasSessionID';
-export const ncUUIDProperty = 'networkCanvasUUID';
-export const ncSourceUUID = 'networkCanvasSourceUUID';
-export const ncTargetUUID = 'networkCanvasTargetUUID';
+const exportIDProperty = 'id'; // property for auto incrementing ID number
+const egoProperty = 'networkCanvasEgoUUID';
+const ncTypeProperty = 'networkCanvasType';
+const ncProtocolNameProperty = 'networkCanvasProtocolName';
+const ncCaseProperty = 'networkCanvasCaseID';
+const ncSessionProperty = 'networkCanvasSessionID';
+const ncUUIDProperty = 'networkCanvasUUID';
+const ncSourceUUID = 'networkCanvasSourceUUID';
+const ncTargetUUID = 'networkCanvasTargetUUID';
+
+module.exports = {
+  caseProperty,
+  edgeSourceProperty,
+  edgeTargetProperty,
+  egoProperty,
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  exportIDProperty, // property for auto incrementing ID number
+  ncCaseProperty,
+  ncProtocolNameProperty,
+  ncSessionProperty,
+  ncSourceUUID,
+  ncTargetUUID,
+  ncTypeProperty,
+  ncUUIDProperty,
+  protocolName,
+  protocolProperty,
+  remoteProtocolProperty,
+  sessionExportTimeProperty,
+  sessionFinishTimeProperty,
+  sessionProperty,
+  sessionStartTimeProperty,
+};


### PR DESCRIPTION
This module is also used on the nodejs side, so without transcompilation this module needs to use the commonjs format.

Default exports have been replaced with:

```
module.exports = {
  default: NamedModule,
  NamedModule,
};
```

Which should mean that commonjs consumers can use `const { NamedModule } = require('./NamedModule');` and es6 consumers can use `import NamedModule from './NamedModule';` or `import { NamedModule } from './NamedModule';`

These updates should just drop into https://github.com/complexdatacollective/Network-Canvas without the need for any changes.

Fixes #11 