### PR TITLE
Screen space for layout variables as additional property

### DIFF
--- a/src/formatters/graphml/__tests__/createGraphML-test.js
+++ b/src/formatters/graphml/__tests__/createGraphML-test.js
@@ -32,7 +32,6 @@ describe('buildGraphML', () => {
 
   it('produces a graphml document', () => {
     expect(xml.getElementsByTagName('graphml')).toHaveLength(1);
-    console.log(xml.toString());
   });
 
   it('creates a single graph element when not merging', () => {

--- a/src/formatters/graphml/__tests__/createGraphML-test.js
+++ b/src/formatters/graphml/__tests__/createGraphML-test.js
@@ -32,6 +32,7 @@ describe('buildGraphML', () => {
 
   it('produces a graphml document', () => {
     expect(xml.getElementsByTagName('graphml')).toHaveLength(1);
+    console.log(xml.toString());
   });
 
   it('creates a single graph element when not merging', () => {
@@ -84,8 +85,8 @@ describe('buildGraphML', () => {
     const nodeSansNull = xml.getElementsByTagName('node')[0];
     const anotherSansNull = xml.getElementsByTagName('node')[1];
     const nodeWithNull = xml.getElementsByTagName('node')[2];
-    expect(nodeSansNull.getElementsByTagName('data').length).toEqual(7);
-    expect(anotherSansNull.getElementsByTagName('data').length).toEqual(7);
+    expect(nodeSansNull.getElementsByTagName('data').length).toEqual(9);
+    expect(anotherSansNull.getElementsByTagName('data').length).toEqual(9);
     expect(nodeWithNull.getElementsByTagName('data').length).toEqual(5);
   });
 

--- a/src/formatters/graphml/createGraphML.js
+++ b/src/formatters/graphml/createGraphML.js
@@ -7,7 +7,7 @@ const {
   getAttributePropertyFromCodebook,
   formatXml,
 } = require('./helpers');
-const VariableType = require('../../utils/protocol-consts');
+const { VariableType } = require('../../utils/protocol-consts');
 const {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
@@ -501,8 +501,8 @@ const generateDataElements = (
           if (exportOptions.globalOptions.useScreenLayoutCoordinates) {
             const screenSpaceXCoord = (xCoord * exportOptions.globalOptions.screenLayoutWidth).toFixed(2);
             const screenSpaceYCoord = ((1.0 - yCoord) * exportOptions.globalOptions.screenLayoutHeight).toFixed(2);
-            domElement.appendChild(createDataElement(document, { key: `${key}screenSpaceX` }, screenSpaceXCoord));
-            domElement.appendChild(createDataElement(document, { key: `${key}screenSpaceY` }, screenSpaceYCoord));
+            domElement.appendChild(createDataElement(document, { key: `${key}_screenSpaceX` }, screenSpaceXCoord));
+            domElement.appendChild(createDataElement(document, { key: `${key}_screenSpaceY` }, screenSpaceYCoord));
           }
 
         // Handle non-codebook variables

--- a/src/formatters/graphml/createGraphML.js
+++ b/src/formatters/graphml/createGraphML.js
@@ -372,9 +372,11 @@ const generateEgoDataElements = (
         fragment += formatAndSerialize(createDataElement(document, { key: `${key}_X` }, xCoord));
         fragment += formatAndSerialize(createDataElement(document, { key: `${key}_Y` }, yCoord));
 
+        const { screenLayoutWidth, screenLayoutHeight } = exportOptions.globalOptions;
+
         if (exportOptions.globalOptions.useScreenLayoutCoordinates) {
-          const screenSpaceXCoord = (xCoord * exportOptions.globalOptions.screenLayoutWidth).toFixed(2);
-          const screenSpaceYCoord = ((1.0 - yCoord) * exportOptions.globalOptions.screenLayoutHeight).toFixed(2);
+          const screenSpaceXCoord = (xCoord * screenLayoutWidth).toFixed(2);
+          const screenSpaceYCoord = ((1.0 - yCoord) * screenLayoutHeight).toFixed(2);
           fragment += formatAndSerialize(createDataElement(document, { key: `${key}_screenSpaceX` }, screenSpaceXCoord));
           fragment += formatAndSerialize(createDataElement(document, { key: `${key}_screenSpaceY` }, screenSpaceYCoord));
         }
@@ -498,9 +500,11 @@ const generateDataElements = (
           domElement.appendChild(createDataElement(document, { key: `${key}_X` }, xCoord));
           domElement.appendChild(createDataElement(document, { key: `${key}_Y` }, yCoord));
 
+          const { screenLayoutWidth, screenLayoutHeight } = exportOptions.globalOptions;
+
           if (exportOptions.globalOptions.useScreenLayoutCoordinates) {
-            const screenSpaceXCoord = (xCoord * exportOptions.globalOptions.screenLayoutWidth).toFixed(2);
-            const screenSpaceYCoord = ((1.0 - yCoord) * exportOptions.globalOptions.screenLayoutHeight).toFixed(2);
+            const screenSpaceXCoord = (xCoord * screenLayoutWidth).toFixed(2);
+            const screenSpaceYCoord = ((1.0 - yCoord) * screenLayoutHeight).toFixed(2);
             domElement.appendChild(createDataElement(document, { key: `${key}_screenSpaceX` }, screenSpaceXCoord));
             domElement.appendChild(createDataElement(document, { key: `${key}_screenSpaceY` }, screenSpaceYCoord));
           }

--- a/src/formatters/graphml/helpers.js
+++ b/src/formatters/graphml/helpers.js
@@ -1,5 +1,5 @@
 const { isNil } = require('lodash');
-const VariableType = require('../../utils/protocol-consts');
+const { VariableType } = require('../../utils/protocol-consts');
 const { entityAttributesProperty } = require('../../utils/reservedAttributes');
 
 const getEntityAttributes = node => (node && node[entityAttributesProperty]) || {};

--- a/src/formatters/network.js
+++ b/src/formatters/network.js
@@ -36,21 +36,23 @@ const processEntityVariables = (entity, entityType, codebook, exportOptions) => 
 
       if (attributeType === 'layout') {
         // Process screenLayoutCoordinates option
-        let xCoord;
-        let yCoord;
-        if (attributeData && exportOptions.globalOptions.useScreenLayoutCoordinates) {
-          xCoord = (attributeData.x * exportOptions.globalOptions.screenLayoutWidth).toFixed(2);
-          yCoord = ((1.0 - attributeData.y) * exportOptions.globalOptions.screenLayoutHeight)
-            .toFixed(2);
-        } else {
-          xCoord = attributeData && attributeData.x;
-          yCoord = attributeData && attributeData.y;
-        }
+        const xCoord = attributeData && attributeData.x;
+        const yCoord = attributeData && attributeData.y;
+
+        const screenSpaceAttributues = attributeData && exportOptions.globalOptions.useScreenLayoutCoordinates ?
+        {
+          [`${attributeName}screenSpaceX`]: (attributeData.x * exportOptions.globalOptions.screenLayoutWidth).toFixed(2),
+          [`${attributeName}screenSpaceY`]: ((1.0 - attributeData.y) * exportOptions.globalOptions.screenLayoutHeight).toFixed(2),
+        } :
+        {};
 
         const layoutAttrs = {
           [`${attributeName}_x`]: xCoord,
           [`${attributeName}_y`]: yCoord,
+          [`${attributeName}screenSpaceX`]: xCoord,
+          [`${attributeName}screenSpaceY`]: yCoord,
         };
+
         return { ...accumulatedAttributes, ...layoutAttrs };
       }
 

--- a/src/formatters/network.js
+++ b/src/formatters/network.js
@@ -39,12 +39,18 @@ const processEntityVariables = (entity, entityType, codebook, exportOptions) => 
         const xCoord = attributeData && attributeData.x;
         const yCoord = attributeData && attributeData.y;
 
-        const screenSpaceAttributes = attributeData && exportOptions.globalOptions.useScreenLayoutCoordinates ?
-        {
-          [`${attributeName}_screenSpaceX`]: (attributeData.x * exportOptions.globalOptions.screenLayoutWidth).toFixed(2),
-          [`${attributeName}_screenSpaceY`]: ((1.0 - attributeData.y) * exportOptions.globalOptions.screenLayoutHeight).toFixed(2),
-        } :
-        {};
+        const {
+          screenLayoutWidth,
+          screenLayoutHeight,
+          useScreenLayoutCoordinates,
+        } = exportOptions.globalOptions;
+
+        const screenSpaceAttributes = attributeData && useScreenLayoutCoordinates
+          ? {
+            [`${attributeName}_screenSpaceX`]: (attributeData.x * screenLayoutWidth).toFixed(2),
+            [`${attributeName}_screenSpaceY`]: ((1.0 - attributeData.y) * screenLayoutHeight).toFixed(2),
+          }
+          : {};
 
         const layoutAttrs = {
           [`${attributeName}_x`]: xCoord,

--- a/src/formatters/network.js
+++ b/src/formatters/network.js
@@ -39,18 +39,17 @@ const processEntityVariables = (entity, entityType, codebook, exportOptions) => 
         const xCoord = attributeData && attributeData.x;
         const yCoord = attributeData && attributeData.y;
 
-        const screenSpaceAttributues = attributeData && exportOptions.globalOptions.useScreenLayoutCoordinates ?
+        const screenSpaceAttributes = attributeData && exportOptions.globalOptions.useScreenLayoutCoordinates ?
         {
-          [`${attributeName}screenSpaceX`]: (attributeData.x * exportOptions.globalOptions.screenLayoutWidth).toFixed(2),
-          [`${attributeName}screenSpaceY`]: ((1.0 - attributeData.y) * exportOptions.globalOptions.screenLayoutHeight).toFixed(2),
+          [`${attributeName}_screenSpaceX`]: (attributeData.x * exportOptions.globalOptions.screenLayoutWidth).toFixed(2),
+          [`${attributeName}_screenSpaceY`]: ((1.0 - attributeData.y) * exportOptions.globalOptions.screenLayoutHeight).toFixed(2),
         } :
         {};
 
         const layoutAttrs = {
           [`${attributeName}_x`]: xCoord,
           [`${attributeName}_y`]: yCoord,
-          [`${attributeName}screenSpaceX`]: xCoord,
-          [`${attributeName}screenSpaceY`]: yCoord,
+          ...screenSpaceAttributes,
         };
 
         return { ...accumulatedAttributes, ...layoutAttrs };

--- a/src/utils/protocol-consts.js
+++ b/src/utils/protocol-consts.js
@@ -12,4 +12,4 @@ const VariableType = Object.freeze({
   datetime: 'datetime',
 });
 
-module.exports = VariableType;
+module.exports = { VariableType };


### PR DESCRIPTION
This updates the graphml and csv exports to add additional `_screenSpaceX` and `_screenSpaceY` attributes when `useScreenLayoutCoordinates` is set, rather than transposing the value.

Have attached example export:

[networkCanvasExport.zip](https://github.com/complexdatacollective/network-exporters/files/5440057/networkCanvasExport.zip)

**Bugfix**

Additionally changes the VariableType export in protocol-consts to a named export to fix a reference in Network Canvas, and for consistency.

Resolves #15