### PR TITLE
Feature/queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5434,6 +5434,14 @@
         "zip-stream": "^3.0.1"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -5603,12 +5611,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/plugin-transform-runtime": "^7.11.0",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.10.1",
+    "async": "^3.2.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -70,7 +70,7 @@ class FileExportManager {
         .catch((result) => {
           logger.log('task result (fail):', result);
         });
-    }, 1);
+    }, 10);
 
     this.events = new EventEmitter();
   }
@@ -161,7 +161,7 @@ class FileExportManager {
             this.emit('update', ProgressMessages.Merging);
             return unionOfNetworks(sessionsByProtocol);
           })
-          .then(async (unifiedSessions) => {
+          .then((unifiedSessions) => {
             if (cancelled) {
               return Promise.reject(new UserCancelledExport());
             }
@@ -244,9 +244,8 @@ class FileExportManager {
               results.push(result);
             });
 
-            await this.q.drain();
-
-            return results;
+            return new Promise((resolve, reject) =>
+              this.q.drain().then(() => resolve(results)).catch(reject));
           })
           // Then, Zip the result.
           .then((exportedPaths) => {

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -1,7 +1,6 @@
 /* eslint-disable global-require */
 const { merge, isEmpty, groupBy } = require('lodash');
 const { EventEmitter } = require('eventemitter3');
-const logger = require('electron-log');
 const queue = require('async/queue');
 const {
   protocolProperty,
@@ -23,7 +22,6 @@ const { ExportError, ErrorMessages } = require('./errors/ExportError');
 const ProgressMessages = require('./ProgressMessages');
 const UserCancelledExport = require('./errors/UserCancelledExport');
 const { isElectron } = require('./utils/Environment');
-
 
 const defaultCSVOptions = {
   adjacencyMatrix: false,
@@ -200,7 +198,6 @@ class FileExportManager {
                     verifySessionVariables(session.sessionVariables);
                   }
                 } catch (e) {
-                  logger.log('Export error:', e);
                   failed.push(e);
                   return;
                 }

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -63,6 +63,15 @@ class FileExportManager {
   constructor(exportOptions = {}) {
     this.exportOptions = getOptions(exportOptions);
 
+    // This queue instance accepts one or more promises and limits their
+    // concurrency for better usability in consuming apps
+    this.q = queue((task, callback) => {
+      task().then(callback)
+        .catch((result) => {
+          logger.log('task result (fail):', result);
+        });
+    }, 1);
+
     this.events = new EventEmitter();
   }
 
@@ -95,8 +104,6 @@ class FileExportManager {
    */
   exportSessions(sessions, protocols) {
     let tmpDir; // Temporary directory location
-    let cancelled = false; // Top-level cancelled property used to abort promise chain
-    let q; // Will contain async.queue in exportPromise;
 
     const exportFormats = [
       ...(this.exportOptions.exportGraphML ? ['graphml'] : []),
@@ -123,235 +130,229 @@ class FileExportManager {
       return Promise.reject(new ExportError(ErrorMessages.MissingParameters));
     }
 
-    const exportPromise = makeTempDir().then((dir) => { tmpDir = dir; })
-      // Delay for 2 seconds to give consumer UI time to render a toast
-      .then(sleep)
-      // Insert a reference to the ego ID into all nodes and edges
-      .then(() => {
-        this.emit('update', ProgressMessages.Formatting);
-        // Insert a reference to the ego ID into all nodes and edges
-        return insertEgoIntoSessionNetworks(sessions);
-      })
-      // Resequence IDs for this export
-      .then(sessionsWithEgo => resequenceIds(sessionsWithEgo))
-      // Group sessions by protocol UUID
-      .then(sessionsWithResequencedIDs => groupBy(sessionsWithResequencedIDs, `sessionVariables.${protocolProperty}`))
-      // Then, process the union option
-      .then((sessionsByProtocol) => {
-        if (cancelled) {
-          return Promise.reject(new UserCancelledExport());
-        }
+    const exportPromise = new Promise((resolveExport) => {
+      let cancelled = false;
+      const results = [];
 
-        if (!this.exportOptions.globalOptions.unifyNetworks) {
-          return sessionsByProtocol;
-        }
-
-        this.emit('update', ProgressMessages.Merging);
-        return unionOfNetworks(sessionsByProtocol);
-      })
-      .then((unifiedSessions) => {
-        if (cancelled) {
-          return Promise.reject(new UserCancelledExport());
-        }
-
-        return new Promise((resolve) => {
-          const results = [];
-          const promisedExports = [];
-
-          q = queue((task, callback) => {
-            task().then(sleep(2000)).then((result) => {
-              results.push(result);
-              callback();
-            }).catch((result) => {
-              logger.log('task result (fail):', result);
-              callback();
-            });
-          }, 1);
-
-          // Create an array of promises representing each session in each export format
-          const finishedSessions = [];
-          const sessionExportTotal = this.exportOptions.globalOptions.unifyNetworks
-            ? Object.keys(unifiedSessions).length : sessions.length;
-
-          Object.keys(unifiedSessions).forEach((protocolUUID) => {
-            // Reject if no protocol was provided for this session
-            if (!protocols[protocolUUID]) {
-              throw new ExportError(ErrorMessages.MissingParameters);
+      const run = () =>
+        makeTempDir().then((dir) => { tmpDir = dir; })
+          // Delay for 2 seconds to give consumer UI time to render a toast
+          .then(sleep)
+          // Insert a reference to the ego ID into all nodes and edges
+          .then(() => {
+            this.emit('update', ProgressMessages.Formatting);
+            // Insert a reference to the ego ID into all nodes and edges
+            return insertEgoIntoSessionNetworks(sessions);
+          })
+          // Resequence IDs for this export
+          .then(sessionsWithEgo => resequenceIds(sessionsWithEgo))
+          // Group sessions by protocol UUID
+          .then(sessionsWithResequencedIDs => groupBy(sessionsWithResequencedIDs, `sessionVariables.${protocolProperty}`))
+          // Then, process the union option
+          .then((sessionsByProtocol) => {
+            if (cancelled) {
+              return Promise.reject(new UserCancelledExport());
             }
 
-            unifiedSessions[protocolUUID].forEach((session) => {
-              // Skip if sessions don't have required sessionVariables
-              try {
-                if (this.exportOptions.globalOptions.unifyNetworks) {
-                  Object.values(session.sessionVariables)
-                    .forEach((sessionVariables) => {
-                      verifySessionVariables(sessionVariables);
-                    });
-                } else {
-                  verifySessionVariables(session.sessionVariables);
-                }
-              } catch (e) {
-                logger.log('Export error:', e);
-                return;
+            if (!this.exportOptions.globalOptions.unifyNetworks) {
+              return sessionsByProtocol;
+            }
+
+            this.emit('update', ProgressMessages.Merging);
+            return unionOfNetworks(sessionsByProtocol);
+          })
+          .then(async (unifiedSessions) => {
+            if (cancelled) {
+              return Promise.reject(new UserCancelledExport());
+            }
+
+            const promisedExports = [];
+
+            // Create an array of promises representing each session in each export format
+            const finishedSessions = [];
+            const sessionExportTotal = this.exportOptions.globalOptions.unifyNetworks
+              ? Object.keys(unifiedSessions).length : sessions.length;
+
+            Object.keys(unifiedSessions).forEach((protocolUUID) => {
+              // Reject if no protocol was provided for this session
+              if (!protocols[protocolUUID]) {
+                throw new ExportError(ErrorMessages.MissingParameters);
               }
 
-              const protocol = protocols[protocolUUID];
-              const prefix = getFilePrefix(
-                session,
-                protocol,
-                this.exportOptions.globalOptions.unifyNetworks,
-              );
+              unifiedSessions[protocolUUID].forEach((session) => {
+                // Skip if sessions don't have required sessionVariables
+                try {
+                  if (this.exportOptions.globalOptions.unifyNetworks) {
+                    Object.values(session.sessionVariables)
+                      .forEach((sessionVariables) => {
+                        verifySessionVariables(sessionVariables);
+                      });
+                  } else {
+                    verifySessionVariables(session.sessionVariables);
+                  }
+                } catch (e) {
+                  logger.log('Export error:', e);
+                  return;
+                }
 
-              // Returns promise resolving to filePath for each format exported
-              // ['file1', ['file1_person', 'file1_place']]
-              exportFormats.forEach((format) => {
-                // partitioning network based on node and edge type so we can create
-                // an individual export file for each type
-                const partitionedNetworks = partitionNetworkByType(
-                  protocol.codebook,
+                const protocol = protocols[protocolUUID];
+                const prefix = getFilePrefix(
                   session,
-                  format,
+                  protocol,
+                  this.exportOptions.globalOptions.unifyNetworks,
                 );
 
-                partitionedNetworks.forEach((partitionedNetwork) => {
-                  const partitionedEntity = partitionedNetwork.partitionEntity;
-                  promisedExports.push(() => exportFile(
-                    prefix,
-                    partitionedEntity,
-                    format,
-                    tmpDir,
-                    partitionedNetwork,
+                // Returns promise resolving to filePath for each format exported
+                // ['file1', ['file1_person', 'file1_place']]
+                exportFormats.forEach((format) => {
+                  // partitioning network based on node and edge type so we can create
+                  // an individual export file for each type
+                  const partitionedNetworks = partitionNetworkByType(
                     protocol.codebook,
-                    this.exportOptions,
-                  ).then((result) => {
-                    if (!finishedSessions.includes(prefix)) {
-                      this.emit('session-exported', session.sessionVariables.sessionId);
-                      this.emit('update', ProgressMessages.ExportSession(finishedSessions.length + 1, sessionExportTotal));
-                      finishedSessions.push(prefix);
-                    }
-                    return result;
-                  }).catch((error) => {
-                    this.emit('error', `Encoding ${prefix} failed: ${error.message}`);
-                    return Promise.reject(error);
-                  }));
+                    session,
+                    format,
+                  );
+
+                  partitionedNetworks.forEach((partitionedNetwork) => {
+                    const partitionedEntity = partitionedNetwork.partitionEntity;
+                    promisedExports.push(() => exportFile(
+                      prefix,
+                      partitionedEntity,
+                      format,
+                      tmpDir,
+                      partitionedNetwork,
+                      protocol.codebook,
+                      this.exportOptions,
+                    ).then((result) => {
+                      if (!finishedSessions.includes(prefix)) {
+                        this.emit('session-exported', session.sessionVariables.sessionId);
+                        this.emit('update', ProgressMessages.ExportSession(finishedSessions.length + 1, sessionExportTotal));
+                        finishedSessions.push(prefix);
+                      }
+                      return result;
+                    }).catch((error) => {
+                      this.emit('error', `Encoding ${prefix} failed: ${error.message}`);
+                      return Promise.reject(error);
+                    }));
+                  });
                 });
               });
             });
-          });
 
-          
-          q.push(promisedExports, something => logger.log('push callback:', something)); // Update status with queue callback?
-          // q.push(promisedExports);
-          q.drain().then(() => {
-            resolve(results);
-          });
-        });
-      })
-      // Then, Zip the result.
-      .then((exportedPaths) => {
-        if (cancelled) {
-          return Promise.reject(new UserCancelledExport());
-        }
+            this.q.push(promisedExports, (result) => {
+              logger.log('Task finished:', result);
+              results.push(result);
+            });
 
-        // FatalError if no sessions survived the cull
-        if (exportedPaths.length === 0) {
-          throw new ExportError(ErrorMessages.NothingToExport);
-        }
+            await this.q.drain();
 
-        // Start the zip process, and attach a callback to the update
-        // progress event.
-        this.emit('update', ProgressMessages.ZipStart);
-        return archive(exportedPaths, tmpDir, (percent) => {
-          this.emit('update', ProgressMessages.ZipProgress(percent));
-        });
-      })
-      .then((zipLocation) => {
-        if (cancelled) {
-          return Promise.reject(new UserCancelledExport());
-        }
-
-        // Prompt the user for a path to save the ZIP (electron)
-        // or open the share dialog (cordova)
-        this.emit('update', ProgressMessages.Saving);
-        return new Promise((resolve, reject) => {
-          if (isElectron()) {
-            let electron;
-
-            if (typeof window !== 'undefined' && window) {
-              electron = window.require('electron').remote;
-            } else {
-              // if no window object assume we are in nodejs environment (Electron main)
-              // no remote needed
-              electron = require('electron');
+            return results;
+          })
+          // Then, Zip the result.
+          .then((exportedPaths) => {
+            if (cancelled) {
+              return Promise.reject(new UserCancelledExport());
             }
 
-            const { dialog } = electron;
-            const browserWindow = first(electron.BrowserWindow.getAllWindows());
+            // FatalError if no sessions survived the cull
+            if (exportedPaths.length === 0) {
+              throw new ExportError(ErrorMessages.NothingToExport);
+            }
 
-            dialog.showSaveDialog(
-              browserWindow,
-              {
-                filters: [{ name: 'zip', extensions: ['zip'] }],
-                defaultPath: 'networkCanvasExport.zip',
-              },
-            )
-              .then(({ canceled, filePath }) => {
-                if (canceled) {
-                  this.emit('cancelled', ProgressMessages.Cancelled);
-                  resolve();
+            // Start the zip process, and attach a callback to the update
+            // progress event.
+            this.emit('update', ProgressMessages.ZipStart);
+            return archive(exportedPaths, tmpDir, (percent) => {
+              this.emit('update', ProgressMessages.ZipProgress(percent));
+            });
+          })
+          .then((zipLocation) => {
+            if (cancelled) {
+              return Promise.reject(new UserCancelledExport());
+            }
+
+            // Prompt the user for a path to save the ZIP (electron)
+            // or open the share dialog (cordova)
+            this.emit('update', ProgressMessages.Saving);
+            return new Promise((resolve, reject) => {
+              if (isElectron()) {
+                let electron;
+
+                if (typeof window !== 'undefined' && window) {
+                  electron = window.require('electron').remote;
+                } else {
+                  // if no window object assume we are in nodejs environment (Electron main)
+                  // no remote needed
+                  electron = require('electron');
                 }
 
-                rename(zipLocation, filePath)
-                  .then(() => {
-                    const { shell } = electron;
-                    shell.showItemInFolder(filePath);
-                    resolve();
-                  })
-                  .catch(reject);
-              });
-          }
+                const { dialog } = electron;
+                const browserWindow = first(electron.BrowserWindow.getAllWindows());
 
-          if (isCordova()) {
-            getFileNativePath(zipLocation)
-              .then((nativePath) => {
-                window.plugins.socialsharing.shareWithOptions({
-                  message: 'Your zipped network canvas data.', // not supported on some apps
-                  subject: 'network canvas export',
-                  files: [nativePath],
-                  chooserTitle: 'Share zip file via', // Android only
-                }, resolve, reject);
-              });
-          }
-        });
-      })
-      .then(() => {
-        if (cancelled) {
-          return Promise.reject(new UserCancelledExport());
-        }
+                dialog.showSaveDialog(
+                  browserWindow,
+                  {
+                    filters: [{ name: 'zip', extensions: ['zip'] }],
+                    defaultPath: 'networkCanvasExport.zip',
+                  },
+                )
+                  .then(({ canceled, filePath }) => {
+                    if (canceled) {
+                      this.emit('cancelled', ProgressMessages.Cancelled);
+                      resolve();
+                    }
 
-        this.emit('finished', ProgressMessages.Finished);
+                    rename(zipLocation, filePath)
+                      .then(() => {
+                        const { shell } = electron;
+                        shell.showItemInFolder(filePath);
+                        resolve();
+                      })
+                      .catch(reject);
+                  });
+              }
+
+              if (isCordova()) {
+                getFileNativePath(zipLocation)
+                  .then((nativePath) => {
+                    window.plugins.socialsharing.shareWithOptions({
+                      message: 'Your zipped network canvas data.', // not supported on some apps
+                      subject: 'network canvas export',
+                      files: [nativePath],
+                      chooserTitle: 'Share zip file via', // Android only
+                    }, resolve, reject);
+                  });
+              }
+            });
+          })
+          .then(() => {
+            if (cancelled) {
+              return Promise.reject(new UserCancelledExport());
+            }
+
+            this.emit('finished', ProgressMessages.Finished);
+            cleanUp();
+
+            return Promise.resolve();
+          })
+          .catch((err) => {
+            // We don't throw if this is an error from user cancelling
+            if (err instanceof UserCancelledExport) {
+              return;
+            }
+
+            cleanUp();
+            throw err;
+          });
+
+      const abort = () => {
+        this.q.kill();
+        cancelled = true;
         cleanUp();
+      };
 
-        return Promise.resolve();
-      })
-      .catch((err) => {
-        // We don't throw if this is an error from user cancelling
-        if (err instanceof UserCancelledExport) {
-          return;
-        }
-
-        cleanUp();
-        throw err;
-      });
-
-    exportPromise.abort = () => {
-      logger.log('export promise abort', q.length());
-      q.kill();
-      cancelled = true;
-      cleanUp();
-    };
-
-    logger.log('about to return exportPromise', exportPromise, exportPromise.abort);
+      resolveExport({ run, abort });
+    });
 
     return exportPromise;
   }

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -159,14 +159,14 @@ class FileExportManager {
           const promisedExports = [];
 
           q = queue((task, callback) => {
-            task().then((result) => {
+            task().then(sleep(2000)).then((result) => {
               results.push(result);
               callback();
             }).catch((result) => {
               logger.log('task result (fail):', result);
               callback();
             });
-          }, 1000);
+          }, 1);
 
           // Create an array of promises representing each session in each export format
           const finishedSessions = [];
@@ -239,7 +239,9 @@ class FileExportManager {
             });
           });
 
-          q.push(promisedExports, something => logger.log('push callback:', something));
+          
+          q.push(promisedExports, something => logger.log('push callback:', something)); // Update status with queue callback?
+          // q.push(promisedExports);
           q.drain().then(() => {
             resolve(results);
           });
@@ -343,10 +345,13 @@ class FileExportManager {
       });
 
     exportPromise.abort = () => {
+      logger.log('export promise abort', q.length());
       q.kill();
       cancelled = true;
       cleanUp();
     };
+
+    logger.log('about to return exportPromise', exportPromise, exportPromise.abort);
 
     return exportPromise;
   }

--- a/src/FileExportManager.js
+++ b/src/FileExportManager.js
@@ -4,8 +4,6 @@ const { EventEmitter } = require('eventemitter3');
 const logger = require('electron-log');
 const queue = require('async/queue');
 const {
-  caseProperty,
-  sessionProperty,
   protocolProperty,
 } = require('./utils/reservedAttributes');
 const {
@@ -21,11 +19,7 @@ const {
   partitionNetworkByType,
   unionOfNetworks,
 } = require('./formatters/network');
-<<<<<<< HEAD
 const { verifySessionVariables, getFilePrefix, sleep } = require('./utils/general');
-=======
-const { verifySessionVariables, sleep } = require('./utils/general');
->>>>>>> 416fd86763d05bb0f65abdae978bf85a703d7a73
 const { isCordova, isElectron } = require('./utils/Environment');
 const archive = require('./utils/archive');
 const { ExportError, ErrorMessages } = require('./errors/ExportError');
@@ -101,11 +95,8 @@ class FileExportManager {
    */
   exportSessions(sessions, protocols) {
     let tmpDir; // Temporary directory location
-<<<<<<< HEAD
-=======
-    const promisedExports = []; // Will hold array of promises representing each export task
->>>>>>> 416fd86763d05bb0f65abdae978bf85a703d7a73
     let cancelled = false; // Top-level cancelled property used to abort promise chain
+    let q; // Will contain async.queue in exportPromise;
 
     const exportFormats = [
       ...(this.exportOptions.exportGraphML ? ['graphml'] : []),
@@ -132,7 +123,7 @@ class FileExportManager {
       return Promise.reject(new ExportError(ErrorMessages.MissingParameters));
     }
 
-    const exportPromise = makeTempDir().then(dir => { tmpDir = dir; })
+    const exportPromise = makeTempDir().then((dir) => { tmpDir = dir; })
       // Delay for 2 seconds to give consumer UI time to render a toast
       .then(sleep)
       // Insert a reference to the ego ID into all nodes and edges
@@ -165,7 +156,9 @@ class FileExportManager {
 
         return new Promise((resolve) => {
           const results = [];
-          const q = queue((task, callback) => {
+          const promisedExports = [];
+
+          q = queue((task, callback) => {
             task().then((result) => {
               results.push(result);
               callback();
@@ -203,7 +196,11 @@ class FileExportManager {
               }
 
               const protocol = protocols[protocolUUID];
-              const prefix = getFilePrefix(session, protocol, this.exportOptions.globalOptions.unifyNetworks);
+              const prefix = getFilePrefix(
+                session,
+                protocol,
+                this.exportOptions.globalOptions.unifyNetworks,
+              );
 
               // Returns promise resolving to filePath for each format exported
               // ['file1', ['file1_person', 'file1_place']]
@@ -242,7 +239,7 @@ class FileExportManager {
             });
           });
 
-          q.push(promisedExports, (something) => console.log('push callback:', something));
+          q.push(promisedExports, something => logger.log('push callback:', something));
           q.drain().then(() => {
             resolve(results);
           });

--- a/src/ProgressMessages.js
+++ b/src/ProgressMessages.js
@@ -13,18 +13,18 @@ const ProgressMessages = {
   },
   ExportSession: (sessionExportCount, sessionExportTotal) => ({
     progress: 30 + ((50 - 30) * sessionExportCount / sessionExportTotal),
-    statusText: `Exporting ${sessionExportCount} of ${sessionExportTotal} sessions...`,
+    statusText: `Encoding session ${sessionExportCount} of ${sessionExportTotal}...`,
   }),
   ZipStart: {
     progress: 60,
     statusText: 'Creating zip archive...',
   },
   ZipProgress: percent => ({
-    progress: 60 + ((85 - 60) * (percent / 100)), // between ZipStart and Saving
+    progress: 60 + ((95 - 60) * (percent / 100)), // between ZipStart and Saving
     statusText: 'Zipping files...',
   }),
   Saving: {
-    progress: 90,
+    progress: 100,
     statusText: 'Saving file...',
   },
   Finished: {

--- a/src/ProgressMessages.js
+++ b/src/ProgressMessages.js
@@ -31,10 +31,6 @@ const ProgressMessages = {
     progress: 100,
     statusText: 'Export finished.',
   },
-  Cancelled: {
-    progress: 100,
-    statusText: 'Export cancelled.',
-  },
 };
 
 module.exports = ProgressMessages;

--- a/src/ProgressMessages.js
+++ b/src/ProgressMessages.js
@@ -31,6 +31,10 @@ const ProgressMessages = {
     progress: 100,
     statusText: 'Export finished.',
   },
+  Cancelled: {
+    progress: 100,
+    statusText: 'Export cancelled.',
+  },
 };
 
 module.exports = ProgressMessages;

--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -1,6 +1,4 @@
-const fs = require('fs-extra');
 const path = require('path');
-const archiver = require('archiver');
 const JSZip = require('jszip');
 const { getEnvironment, isElectron, isCordova } = require('./Environment');
 const { resolveFileSystemUrl, splitUrl, readFile, newFile, makeFileWriter } = require('./filesystem');
@@ -24,6 +22,8 @@ const archiveOptions = {
  */
 const archiveElectron = (sourcePaths, destinationPath, updateCallback) =>
   new Promise((resolve, reject) => {
+    const fs = require('fs-extra');
+    const archiver = require('archiver');
     const output = fs.createWriteStream(destinationPath);
     const zip = archiver('zip', archiveOptions);
 

--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const path = require('path');
 const JSZip = require('jszip');
 const { getEnvironment, isElectron, isCordova } = require('./Environment');

--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const archiver = require('archiver');
 const JSZip = require('jszip');
@@ -44,7 +44,7 @@ const archiveElectron = (sourcePaths, destinationPath, updateCallback) =>
     });
 
     sourcePaths.forEach((sourcePath) => {
-      zip.append(fs.createReadStream(sourcePath), { name: path.basename(sourcePath) });
+      zip.file(sourcePath, { name: path.basename(sourcePath) });
     });
 
     zip.finalize();

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -110,7 +110,7 @@ const makeTempDir = () => {
     return Promise.reject(new ExportError(ErrorMessages.NoTmpFS));
   }
 
-  return createDirectory(directoryPath).then(dir => isCordova() ? dir.toInternalURL() : dir);
+  return createDirectory(directoryPath).then(dir => (isCordova() ? dir.toInternalURL() : dir));
 };
 
 const userDataPath = inEnvironment((environment) => {

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -110,7 +110,7 @@ const makeTempDir = () => {
     return Promise.reject(new ExportError(ErrorMessages.NoTmpFS));
   }
 
-  return createDirectory(directoryPath);
+  return createDirectory(directoryPath).then(dir => isCordova() ? dir.toInternalURL() : dir);
 };
 
 const userDataPath = inEnvironment((environment) => {

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1,4 +1,4 @@
-
+const sanitizeFilename = require('sanitize-filename');
 const { ExportError, ErrorMessages } = require('../errors/ExportError');
 const {
   caseProperty,
@@ -64,6 +64,16 @@ const getFileExtension = (formatterType) => {
   }
 };
 
+// Determine filename prefix based on if we are exporting a single session
+// or a unified network
+const getFilePrefix = (session, protocol, unifyNetworks) => {
+  if (unifyNetworks) {
+    return sanitizeFilename(protocol.name);
+  }
+
+  return `${sanitizeFilename(session.sessionVariables[caseProperty])}_${session.sessionVariables[sessionProperty]}`;
+}
+
 const extensionPattern = new RegExp(`${Object.values(extensions).join('|')}$`);
 
 module.exports = {
@@ -72,6 +82,7 @@ module.exports = {
   extensions,
   getEntityAttributes,
   getFileExtension,
+  getFilePrefix,
   makeFilename,
   verifySessionVariables,
 };

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -74,7 +74,7 @@ const getFilePrefix = (session, protocol, unifyNetworks) => {
   }
 
   return `${sanitizeFilename(session.sessionVariables[caseProperty])}_${session.sessionVariables[sessionProperty]}`;
-}
+};
 
 const extensionPattern = new RegExp(`${Object.values(extensions).join('|')}$`);
 


### PR DESCRIPTION
We've had issues with large batches of actions executing all at once (but in a single thread) causing apps to become unresponsive. This is usually because we map over a set of items and create a promise for each value, which is immediately invoked. We actual nest several of these operations in `network-exporters`. WIth 4,500  sessions, if CSV and graphML are both selected, `exportFile` is invoked over 30,000 times.

This PR implements a queue system so that concurrency is limited to 100 simultaneous calls, which improves performance substantially (though the parameter may need to be fine-tuned). It also has the added benefit of removing the EMFILE errors on windows because file pointer concurrency in `exportFile` was causing the issue. 

This pushed the error further on in the process, requiring an additional change. I switched from the `update` to the `file` method in node-archiver, as I read that file has its own queue system implemented. This removed the need for the file handle in the archive process.

