### PR TITLE
Use copy rather than rename for last step of export

### DIFF
--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -277,6 +277,27 @@ const rename = inEnvironment((environment) => {
   throw new Error(`rename() not available on platform ${environment}`);
 });
 
+const copy = inEnvironment((environment) => {
+  if (environment === environments.ELECTRON) {
+    const fse = require('fs-extra');
+
+    return (oldPath, newPath) =>
+      fse.copy(oldPath, newPath);
+  }
+
+  if (environment === environments.CORDOVA) {
+    return (oldPath, newPath) =>
+      new Promise(async (resolve, reject) => {
+        const [parent, name] = splitUrl(newPath);
+        const toDirectory = await resolveFileSystemUrl(parent);
+        const fromDirectory = await resolveFileSystemUrl(oldPath);
+        return fromDirectory.copyTo(toDirectory, name, resolve, reject);
+      });
+  }
+
+  throw new Error(`copy() not available on platform ${environment}`);
+});
+
 const removeDirectory = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
     const fse = require('fs-extra');
@@ -662,6 +683,7 @@ const makeTmpDirCopy = inEnvironment((environment) => {
 
 module.exports = {
   appPath,
+  copy,
   createDirectory,
   createReader,
   createWriteStream,

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -285,16 +285,6 @@ const copy = inEnvironment((environment) => {
       fse.copy(oldPath, newPath);
   }
 
-  if (environment === environments.CORDOVA) {
-    return (oldPath, newPath) =>
-      new Promise(async (resolve, reject) => {
-        const [parent, name] = splitUrl(newPath);
-        const toDirectory = await resolveFileSystemUrl(parent);
-        const fromDirectory = await resolveFileSystemUrl(oldPath);
-        return fromDirectory.copyTo(toDirectory, name, resolve, reject);
-      });
-  }
-
   throw new Error(`copy() not available on platform ${environment}`);
 });
 

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -3,7 +3,7 @@ const { first } = require('lodash');
 const sanitizeFilename = require('sanitize-filename');
 const { ExportError, ErrorMessages } = require('../errors/ExportError');
 const { isCordova, isElectron } = require('./Environment');
-const { getFileNativePath, rename } = require('./filesystem');
+const { getFileNativePath, copy } = require('./filesystem');
 const {
   caseProperty,
   sessionProperty,
@@ -122,7 +122,7 @@ const handlePlatformSaveDialog = zipLocation => new Promise((resolve, reject) =>
           resolve();
         }
 
-        rename(zipLocation, filePath)
+        copy(zipLocation, filePath)
           .then(() => {
             const { shell } = electron;
             shell.showItemInFolder(filePath);


### PR DESCRIPTION
This adds a new `copy()` method in filesystem for electron (but not cordova).

It's used in the final step of the export as a replacement for `rename()`, and allows the apps to work as `.snap` packages, as well as exporting accross different devices/drives from where the app is located.