### PR TITLE
Entity resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "lint": "eslint src",
     "test": "jest"
   },
+  "engines": {
+    "node": "12.14.1",
+    "npm": "6.13.4"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/codaco/network-exporters.git"

--- a/src/formatters/graphml/createGraphML.js
+++ b/src/formatters/graphml/createGraphML.js
@@ -621,7 +621,7 @@ function* graphMLGenerator(network, codebook, exportOptions) {
       yield getGraphHeader(exportOptions, network.sessionVariables[sessionID]);
 
       // Add ego to graph
-      if (network.ego[sessionID]) {
+      if (network.ego[sessionID] && codebook.ego) {
         yield generateEgoElements(network.ego[sessionID]);
       }
 
@@ -646,7 +646,7 @@ function* graphMLGenerator(network, codebook, exportOptions) {
     yield getGraphHeader(exportOptions, network.sessionVariables);
 
     // Add ego to graph
-    if (network.ego) {
+    if (network.ego && codebook.ego) {
       yield generateEgoElements(network.ego);
     }
 


### PR DESCRIPTION
This prevents the empty networkCanvasUUID being added to the graphml when no ego codebook is provided, indicating that there are no ego attributes, and thus no ego.

This bug was found in entity resolution, but also applies to protocols without an ego screen.

Required by https://github.com/complexdatacollective/Server/pull/325