### PR TITLE
add tests for null boolean values

### DIFF
--- a/config/mockObjects.js
+++ b/config/mockObjects.js
@@ -17,6 +17,9 @@ export const mockCodebook = {
         'mock-uuid-1': { name: 'firstName', type: 'string' },
         'mock-uuid-2': { name: 'age', type: 'number' },
         'mock-uuid-3': { name: 'layout', type: 'layout' },
+        'mock-uuid-4': { name: 'boolWithValues', type: 'boolean' },
+        'mock-uuid-5': { name: 'nullBool', type: 'boolean' },
+        'mock-uuid-6': { name: 'unusedBool', type: 'boolean' },
       },
     },
   },
@@ -44,9 +47,10 @@ export const mockExportOptions = {
 
 export const mockNetwork = {
   nodes: [
-    { [entityPrimaryKeyProperty]: '1', type: 'mock-node-type', [entityAttributesProperty]: { 'mock-uuid-1': 'Dee', 'mock-uuid-2': 40, 'mock-uuid-3': { x: 0, y: 0 } } },
-    { [entityPrimaryKeyProperty]: '2', type: 'mock-node-type', [entityAttributesProperty]: { 'mock-uuid-1': 'Carl', 'mock-uuid-2': 0, 'mock-uuid-3': { x: 0, y: 0 } } },
-    { [entityPrimaryKeyProperty]: '3', type: 'mock-node-type', [entityAttributesProperty]: { 'mock-uuid-1': 'Jumbo', 'mock-uuid-2': 50, 'mock-uuid-3': null } },
+    { [entityPrimaryKeyProperty]: '1', type: 'mock-node-type', [entityAttributesProperty]: { 'mock-uuid-1': 'Dee', 'mock-uuid-2': 40, 'mock-uuid-3': { x: 0, y: 0 }, 'mock-uuid-4': true, 'mock-uuid-5': null } },
+    { [entityPrimaryKeyProperty]: '2', type: 'mock-node-type', [entityAttributesProperty]: { 'mock-uuid-1': 'Carl', 'mock-uuid-2': 0, 'mock-uuid-3': { x: 0, y: 0 }, 'mock-uuid-4': false, 'mock-uuid-5': null } },
+    { [entityPrimaryKeyProperty]: '3', type: 'mock-node-type', [entityAttributesProperty]: { 'mock-uuid-1': 'Jumbo', 'mock-uuid-2': 50, 'mock-uuid-3': null, 'mock-uuid-4': true, 'mock-uuid-5': null } },
+    { [entityPrimaryKeyProperty]: '4', type: 'mock-node-type', [entityAttributesProperty]: { 'mock-uuid-1': 'Francis', 'mock-uuid-2': 10, 'mock-uuid-3': {x: 0, y: 0 }, 'mock-uuid-4': null, 'mock-uuid-5': null } },
   ],
   edges: [
     { from: '1', to: '2', type: 'mock-edge-type' },

--- a/src/formatters/graphml/__tests__/createGraphML-test.js
+++ b/src/formatters/graphml/__tests__/createGraphML-test.js
@@ -17,7 +17,6 @@ const buildXML = (...args) => {
 };
 
 describe('buildGraphML', () => {
-
   const edgeType = mockCodebook.edge['mock-edge-type'].name;
   const nodeType = mockCodebook.node['mock-node-type'].name;
   const codebook = mockCodebook;
@@ -49,7 +48,7 @@ describe('buildGraphML', () => {
   });
 
   it('adds nodes', () => {
-    expect(xml.getElementsByTagName('node')).toHaveLength(3);
+    expect(xml.getElementsByTagName('node')).toHaveLength(4);
   });
 
   it('adds node type', () => {
@@ -127,9 +126,31 @@ describe('buildGraphML', () => {
     const nodeSansNull = xml.getElementsByTagName('node')[0];
     const anotherSansNull = xml.getElementsByTagName('node')[1];
     const nodeWithNull = xml.getElementsByTagName('node')[2];
-    expect(nodeSansNull.getElementsByTagName('data').length).toEqual(9);
-    expect(anotherSansNull.getElementsByTagName('data').length).toEqual(9);
-    expect(nodeWithNull.getElementsByTagName('data').length).toEqual(5);
+    const nodeWithNullBoolean = xml.getElementsByTagName('node')[3];
+    expect(nodeSansNull.getElementsByTagName('data').length).toEqual(10);
+    expect(anotherSansNull.getElementsByTagName('data').length).toEqual(10);
+    expect(nodeWithNull.getElementsByTagName('data').length).toEqual(6);
+    expect(nodeWithNullBoolean.getElementsByTagName('data').length).toEqual(9);
+  });
+
+  it('includes keys for all used variables', () => {
+    const graphData = Array.from(xml.getElementsByTagName('key'))
+      .filter(node => node.getAttribute('for') === 'node')
+      .reduce((acc, node) => ({
+        ...acc,
+        [node.getAttribute('id')]: node.getAttribute('for'),
+      }), {});
+
+    expect(graphData).toMatchObject({
+      'mock-uuid-1': 'node',
+      'mock-uuid-2': 'node',
+      'mock-uuid-3_X': 'node',
+      'mock-uuid-3_screenSpaceY': 'node',
+      'mock-uuid-3_screenSpaceX': 'node',
+      'mock-uuid-3_Y': 'node',
+      'mock-uuid-4': 'node',
+      'mock-uuid-5': 'node',
+    });
   });
 
   describe('with directed edge option', () => {


### PR DESCRIPTION
This just adds a couple of checks that null values are handled as expected:
- *GraphML*: a test was in place for null location values, but this adds one for boolean values (`'excludes null values'` has `nodeWithNullBoolean` now).
- *GraphML*: key is included if the variable is used at all (null or otherwise), but excluded if never used (added test `'includes keys for all used variables'`)
- *CSV*: verified existing test already in place for null values (`'exports null values as blank'`)
- **NOTE**: null categorical variables export as `false` in csv, but are excluded in graphml -- unless there was a non-null value for the variable; keys are included for graphml in either case. Is this expected behavior? Do we want a test for this?

Also double checked this with an exported session from Interviewer to add confidence to what I saw with these tests.